### PR TITLE
docs: fix typo in README.md(s)

### DIFF
--- a/packages/ebec/README.md
+++ b/packages/ebec/README.md
@@ -137,7 +137,8 @@ import { isBaseError, BaseError } from "ebec";
 
 const error = new BaseError();
 
-console.log(isBaseError(error)); // true
+console.log(isBaseError(error));
+// true
 ```
 
 ## License

--- a/packages/ebec/README.md
+++ b/packages/ebec/README.md
@@ -38,7 +38,7 @@ import { BaseError } from 'ebec';
 const error = new BaseError('An error occurred.');
 
 console.log(error.message);
-// An error is occurred.
+// An error occurred.
 ```
 
 **Example #2**

--- a/packages/ebec/README.md
+++ b/packages/ebec/README.md
@@ -136,8 +136,8 @@ This method is used to determine if the error is a basic error or if the error e
 import { isBaseError, BaseError } from "ebec";
 
 const error = new BaseError();
-isBaseError(error);
-// true
+
+console.log(isBaseError(error)); // true
 ```
 
 ## License

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -107,7 +107,7 @@ The following HTTP classes are predefined:
 - 405 `MethodNotAllowedError`
 - 406 `NotAcceptableError`
 - 407 `ProxyAuthenticationRequiredError`
-- 408 `RequesTimeoutError`
+- 408 `RequestTimeoutError`
 - 409 `ConflictError`
 - 410 `GoneError`
 - 411 `LengthRequiredError`


### PR DESCRIPTION
I noticed a few typos when reading through the documentation, thought I'd submit a quick PR to fix them.

I also added a `console.log` to one of the code examples to match the rest of the other examples in the README.

Thanks!