### PR TITLE
feat(http): remove statusMessage as constructor option and derive fro…

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -37,7 +37,6 @@ class BaseError extends Error {
 class HTTPError extends BaseError {
     readonly status: number;           // HTTP status (400-599), defaults to 500
     get statusCode(): number;          // @deprecated — alias for `status`
-    readonly statusMessage?: string;   // HTTP reason phrase (ASCII printable, max 256 chars)
     readonly redirectURL?: string;     // For redirect responses
 }
 ```
@@ -47,12 +46,6 @@ class HTTPError extends BaseError {
 - Invalid status codes (outside 100-599) are sanitized to 500
 - Constructor accepts both `status` and `statusCode` options; `status` takes precedence
 - Generated subclasses use nullish coalescing (`??`) to preserve their default status when the user passes `undefined`
-
-### StatusMessage Sanitization
-
-- Only ASCII printable characters (0x20-0x7E) are allowed
-- Whitespace is trimmed
-- Maximum length is 256 characters
 
 ## Flexible Constructor Pattern
 
@@ -74,7 +67,7 @@ new BaseError(existingError, { code: 'WRAPPED' });
 2. Error instances → `message`, `stack`, `cause` (non-enumerable properties)
 3. Objects passing `checkFn` → merge all enumerable keys (unsafe keys like `__proto__`, `constructor`, `prototype` are filtered)
 
-The `@ebec/core` package creates its extractor with `isOptions()`. The `@ebec/http` package creates its own with an extended `isHTTPErrorOptions()` that also validates `status`, `statusCode`, `statusMessage`, and `redirectURL`.
+The `@ebec/core` package creates its extractor with `isOptions()`. The `@ebec/http` package creates its own with an extended `isHTTPErrorOptions()` that also validates `status`, `statusCode`, and `redirectURL`.
 
 ## Code Generation (HTTP Package)
 

--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -32,7 +32,7 @@ ebec/
 │       │   ├── core-export.ts # Re-exports @ebec/core for ./core subpath
 │       │   ├── utils/
 │       │   │   ├── options.ts     # isHTTPErrorOptions()
-│       │   │   ├── sanitize.ts    # sanitizeStatusCode(), sanitizeStatusMessage()
+│       │   │   ├── sanitize.ts    # sanitizeStatusCode()
 │       │   │   └── status-text.ts # getStatusText()
 │       │   └── errors/
 │       │       ├── base/      # HTTPError, ClientError, ServerError + types

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -33,7 +33,7 @@ import { NotFoundError, InternalServerError } from '@ebec/http';
 const error = new NotFoundError('user not found');
 console.log(error.status);        // 404
 console.log(error.code);          // "NOT_FOUND"
-console.log(error.statusMessage); // "Not Found"
+console.log(error.message);       // "user not found"
 
 // Options input
 const error = new InternalServerError({
@@ -181,7 +181,6 @@ import { BaseError, isBaseError } from '@ebec/http/core';
 ```typescript
 class HTTPError extends BaseError {
     readonly status: number;           // defaults to 500
-    readonly statusMessage?: string;   // ASCII printable, max 256 chars
     readonly redirectURL?: string;
 
     get statusCode(): number;          // @deprecated — alias for `status`
@@ -198,7 +197,6 @@ Extends core `ErrorOptions` with HTTP-specific fields:
 |----------|------|-------------|
 | `status` | `number \| string` | HTTP status code (100-599). Invalid values default to 500. |
 | `statusCode` | `number \| string` | **Deprecated.** Alias for `status`. |
-| `statusMessage` | `string` | Reason phrase. Sanitized to ASCII printable, max 256 chars. |
 | `redirectURL` | `string` | Redirect URL for 3xx-style responses. |
 
 Plus all fields from [`@ebec/core` ErrorOptions](../core#erroroptions).
@@ -218,7 +216,6 @@ Plus all fields from [`@ebec/core` ErrorOptions](../core#erroroptions).
 |----------|-------------|
 | `getStatusText(statusCode)` | Returns the reason phrase for a given status code, or `undefined` if not found |
 | `sanitizeStatusCode(input)` | Parses and validates (100-599), defaults to 500 |
-| `sanitizeStatusMessage(input)` | Strips non-ASCII, trims, caps at 256 chars |
 | `STATUS_TEXTS` | Map of status codes to reason phrases (e.g. `400 → "Bad Request"`) |
 
 ## License

--- a/packages/http/src/errors/base/http.ts
+++ b/packages/http/src/errors/base/http.ts
@@ -1,9 +1,9 @@
 import { BaseError, isBaseError } from '@ebec/core';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 import {
+    getStatusText,
     isHTTPErrorOptions,
     sanitizeStatusCode,
-    sanitizeStatusMessage,
 } from '../../utils';
 import type { IHTTPError } from './types';
 
@@ -14,14 +14,11 @@ export class HTTPError extends BaseError implements IHTTPError {
     readonly status: number;
 
     /**
-     * A status message.
-     */
-    readonly statusMessage?: string;
-
-    /**
      * Specify a redirect URL in case of a http error.
      */
     readonly redirectURL?: string;
+
+    private _statusMessage: string | undefined | null = null;
 
     constructor(input: HTTPErrorInput = {}) {
         const options: HTTPErrorOptions = typeof input === 'string' ? { message: input } : input;
@@ -33,11 +30,22 @@ export class HTTPError extends BaseError implements IHTTPError {
             sanitizeStatusCode(statusCode) :
             500;
 
-        this.statusMessage = options.statusMessage ?
-            sanitizeStatusMessage(options.statusMessage) :
-            undefined;
+        if (!options.message) {
+            this.message = getStatusText(this.status) || 'An error occurred';
+        }
 
         this.redirectURL = options.redirectURL;
+    }
+
+    /**
+     * The HTTP reason phrase derived from the status code.
+     */
+    get statusMessage(): string | undefined {
+        if (this._statusMessage === null) {
+            this._statusMessage = getStatusText(this.status);
+        }
+
+        return this._statusMessage;
     }
 
     /**
@@ -45,6 +53,14 @@ export class HTTPError extends BaseError implements IHTTPError {
      */
     get statusCode(): number {
         return this.status;
+    }
+
+    override toJSON() {
+        return {
+            ...super.toJSON(),
+            status: this.status,
+            statusMessage: this.statusMessage,
+        };
     }
 }
 

--- a/packages/http/src/errors/base/http.ts
+++ b/packages/http/src/errors/base/http.ts
@@ -20,13 +20,7 @@ export class HTTPError extends BaseError implements IHTTPError {
 
     constructor(input: HTTPErrorInput = {}) {
         const options: HTTPErrorOptions = typeof input === 'string' ? { message: input } : input;
-        const statusCode = options.status ?? options.statusCode;
-        const statusCodeSanitized = statusCode != null ?
-            sanitizeStatusCode(statusCode) :
-            500;
-        const statusCodeNormalized = statusCodeSanitized >= 400 && statusCodeSanitized < 600 ?
-            statusCodeSanitized :
-            500;
+        const statusCodeNormalized = sanitizeStatusCode(options.status ?? options.statusCode);
 
         super({
             ...options,

--- a/packages/http/src/errors/base/http.ts
+++ b/packages/http/src/errors/base/http.ts
@@ -18,8 +18,6 @@ export class HTTPError extends BaseError implements IHTTPError {
      */
     readonly redirectURL?: string;
 
-    private _statusMessage: string | undefined | null = null;
-
     constructor(input: HTTPErrorInput = {}) {
         const options: HTTPErrorOptions = typeof input === 'string' ? { message: input } : input;
         const statusCode = options.status ?? options.statusCode;
@@ -38,17 +36,6 @@ export class HTTPError extends BaseError implements IHTTPError {
     }
 
     /**
-     * The HTTP reason phrase derived from the status code.
-     */
-    get statusMessage(): string | undefined {
-        if (this._statusMessage === null) {
-            this._statusMessage = getStatusText(this.status);
-        }
-
-        return this._statusMessage;
-    }
-
-    /**
      * @deprecated Use `status` instead.
      */
     get statusCode(): number {
@@ -59,7 +46,6 @@ export class HTTPError extends BaseError implements IHTTPError {
         return {
             ...super.toJSON(),
             status: this.status,
-            statusMessage: this.statusMessage,
         };
     }
 }

--- a/packages/http/src/errors/base/http.ts
+++ b/packages/http/src/errors/base/http.ts
@@ -22,17 +22,17 @@ export class HTTPError extends BaseError implements IHTTPError {
 
     constructor(input: HTTPErrorInput = {}) {
         const options: HTTPErrorOptions = typeof input === 'string' ? { message: input } : input;
-
-        super(options);
-
         const statusCode = options.status ?? options.statusCode;
-        this.status = statusCode ?
+        const statusCodeNormalized = statusCode ?
             sanitizeStatusCode(statusCode) :
             500;
 
-        if (!options.message) {
-            this.message = getStatusText(this.status) || 'An error occurred';
-        }
+        super({
+            ...options,
+            message: options.message || getStatusText(statusCodeNormalized),
+        });
+
+        this.status = statusCodeNormalized;
 
         this.redirectURL = options.redirectURL;
     }

--- a/packages/http/src/errors/base/http.ts
+++ b/packages/http/src/errors/base/http.ts
@@ -21,8 +21,11 @@ export class HTTPError extends BaseError implements IHTTPError {
     constructor(input: HTTPErrorInput = {}) {
         const options: HTTPErrorOptions = typeof input === 'string' ? { message: input } : input;
         const statusCode = options.status ?? options.statusCode;
-        const statusCodeNormalized = statusCode ?
+        const statusCodeSanitized = statusCode != null ?
             sanitizeStatusCode(statusCode) :
+            500;
+        const statusCodeNormalized = statusCodeSanitized >= 400 && statusCodeSanitized < 600 ?
+            statusCodeSanitized :
             500;
 
         super({

--- a/packages/http/src/errors/base/types.ts
+++ b/packages/http/src/errors/base/types.ts
@@ -6,7 +6,6 @@ export interface IHTTPError extends IBaseError {
      * @deprecated Use `status` instead.
      */
     statusCode: number;
-    statusMessage: string | undefined;
     redirectURL?: string;
 }
 

--- a/packages/http/src/errors/base/types.ts
+++ b/packages/http/src/errors/base/types.ts
@@ -6,7 +6,7 @@ export interface IHTTPError extends IBaseError {
      * @deprecated Use `status` instead.
      */
     statusCode: number;
-    statusMessage?: string;
+    statusMessage: string | undefined;
     redirectURL?: string;
 }
 

--- a/packages/http/src/errors/client/400-bad-request.ts
+++ b/packages/http/src/errors/client/400-bad-request.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const BadRequestErrorOptions = {
     code: 'BAD_REQUEST',
     status: 400,
-    statusMessage: 'Bad Request',
 } as const;
 
 export class BadRequestError extends ClientError {
@@ -14,7 +13,6 @@ export class BadRequestError extends ClientError {
             ...options,
             code: options.code ?? BadRequestErrorOptions.code,
             status: options.status ?? options.statusCode ?? BadRequestErrorOptions.status,
-            statusMessage: options.statusMessage ?? BadRequestErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/401-unauthorized.ts
+++ b/packages/http/src/errors/client/401-unauthorized.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const UnauthorizedErrorOptions = {
     code: 'UNAUTHORIZED',
     status: 401,
-    statusMessage: 'Unauthorized',
 } as const;
 
 export class UnauthorizedError extends ClientError {
@@ -14,7 +13,6 @@ export class UnauthorizedError extends ClientError {
             ...options,
             code: options.code ?? UnauthorizedErrorOptions.code,
             status: options.status ?? options.statusCode ?? UnauthorizedErrorOptions.status,
-            statusMessage: options.statusMessage ?? UnauthorizedErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/403-forbidden.ts
+++ b/packages/http/src/errors/client/403-forbidden.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const ForbiddenErrorOptions = {
     code: 'FORBIDDEN',
     status: 403,
-    statusMessage: 'Forbidden',
 } as const;
 
 export class ForbiddenError extends ClientError {
@@ -14,7 +13,6 @@ export class ForbiddenError extends ClientError {
             ...options,
             code: options.code ?? ForbiddenErrorOptions.code,
             status: options.status ?? options.statusCode ?? ForbiddenErrorOptions.status,
-            statusMessage: options.statusMessage ?? ForbiddenErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/404-not-found.ts
+++ b/packages/http/src/errors/client/404-not-found.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const NotFoundErrorOptions = {
     code: 'NOT_FOUND',
     status: 404,
-    statusMessage: 'Not Found',
 } as const;
 
 export class NotFoundError extends ClientError {
@@ -14,7 +13,6 @@ export class NotFoundError extends ClientError {
             ...options,
             code: options.code ?? NotFoundErrorOptions.code,
             status: options.status ?? options.statusCode ?? NotFoundErrorOptions.status,
-            statusMessage: options.statusMessage ?? NotFoundErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/405-method-not-allowed.ts
+++ b/packages/http/src/errors/client/405-method-not-allowed.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const MethodNotAllowedErrorOptions = {
     code: 'METHOD_NOT_ALLOWED',
     status: 405,
-    statusMessage: 'Method Not Allowed',
 } as const;
 
 export class MethodNotAllowedError extends ClientError {
@@ -14,7 +13,6 @@ export class MethodNotAllowedError extends ClientError {
             ...options,
             code: options.code ?? MethodNotAllowedErrorOptions.code,
             status: options.status ?? options.statusCode ?? MethodNotAllowedErrorOptions.status,
-            statusMessage: options.statusMessage ?? MethodNotAllowedErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/406-not-acceptable.ts
+++ b/packages/http/src/errors/client/406-not-acceptable.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const NotAcceptableErrorOptions = {
     code: 'NOT_ACCEPTABLE',
     status: 406,
-    statusMessage: 'Not Acceptable',
 } as const;
 
 export class NotAcceptableError extends ClientError {
@@ -14,7 +13,6 @@ export class NotAcceptableError extends ClientError {
             ...options,
             code: options.code ?? NotAcceptableErrorOptions.code,
             status: options.status ?? options.statusCode ?? NotAcceptableErrorOptions.status,
-            statusMessage: options.statusMessage ?? NotAcceptableErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/407-proxy-authentication-required.ts
+++ b/packages/http/src/errors/client/407-proxy-authentication-required.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const ProxyAuthenticationRequiredErrorOptions = {
     code: 'PROXY_AUTHENTICATION_REQUIRED',
     status: 407,
-    statusMessage: 'Proxy Authentication Required',
 } as const;
 
 export class ProxyAuthenticationRequiredError extends ClientError {
@@ -14,7 +13,6 @@ export class ProxyAuthenticationRequiredError extends ClientError {
             ...options,
             code: options.code ?? ProxyAuthenticationRequiredErrorOptions.code,
             status: options.status ?? options.statusCode ?? ProxyAuthenticationRequiredErrorOptions.status,
-            statusMessage: options.statusMessage ?? ProxyAuthenticationRequiredErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/408-request-timeout.ts
+++ b/packages/http/src/errors/client/408-request-timeout.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const RequestTimeoutErrorOptions = {
     code: 'REQUEST_TIMEOUT',
     status: 408,
-    statusMessage: 'Request Timeout',
 } as const;
 
 export class RequestTimeoutError extends ClientError {
@@ -14,7 +13,6 @@ export class RequestTimeoutError extends ClientError {
             ...options,
             code: options.code ?? RequestTimeoutErrorOptions.code,
             status: options.status ?? options.statusCode ?? RequestTimeoutErrorOptions.status,
-            statusMessage: options.statusMessage ?? RequestTimeoutErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/409-conflict.ts
+++ b/packages/http/src/errors/client/409-conflict.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const ConflictErrorOptions = {
     code: 'CONFLICT',
     status: 409,
-    statusMessage: 'Conflict',
 } as const;
 
 export class ConflictError extends ClientError {
@@ -14,7 +13,6 @@ export class ConflictError extends ClientError {
             ...options,
             code: options.code ?? ConflictErrorOptions.code,
             status: options.status ?? options.statusCode ?? ConflictErrorOptions.status,
-            statusMessage: options.statusMessage ?? ConflictErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/410-gone.ts
+++ b/packages/http/src/errors/client/410-gone.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const GoneErrorOptions = {
     code: 'GONE',
     status: 410,
-    statusMessage: 'Gone',
 } as const;
 
 export class GoneError extends ClientError {
@@ -14,7 +13,6 @@ export class GoneError extends ClientError {
             ...options,
             code: options.code ?? GoneErrorOptions.code,
             status: options.status ?? options.statusCode ?? GoneErrorOptions.status,
-            statusMessage: options.statusMessage ?? GoneErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/411-length-required.ts
+++ b/packages/http/src/errors/client/411-length-required.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const LengthRequiredErrorOptions = {
     code: 'LENGTH_REQUIRED',
     status: 411,
-    statusMessage: 'Length Required',
 } as const;
 
 export class LengthRequiredError extends ClientError {
@@ -14,7 +13,6 @@ export class LengthRequiredError extends ClientError {
             ...options,
             code: options.code ?? LengthRequiredErrorOptions.code,
             status: options.status ?? options.statusCode ?? LengthRequiredErrorOptions.status,
-            statusMessage: options.statusMessage ?? LengthRequiredErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/412-precondition-failed.ts
+++ b/packages/http/src/errors/client/412-precondition-failed.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const PreconditionFailedErrorOptions = {
     code: 'PRECONDITION_FAILED',
     status: 412,
-    statusMessage: 'Precondition Failed',
 } as const;
 
 export class PreconditionFailedError extends ClientError {
@@ -14,7 +13,6 @@ export class PreconditionFailedError extends ClientError {
             ...options,
             code: options.code ?? PreconditionFailedErrorOptions.code,
             status: options.status ?? options.statusCode ?? PreconditionFailedErrorOptions.status,
-            statusMessage: options.statusMessage ?? PreconditionFailedErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/413-request-entity-too-large.ts
+++ b/packages/http/src/errors/client/413-request-entity-too-large.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const RequestEntityTooLargeErrorOptions = {
     code: 'REQUEST_ENTITY_TOO_LARGE',
     status: 413,
-    statusMessage: 'Request Entity Too Large',
 } as const;
 
 export class RequestEntityTooLargeError extends ClientError {
@@ -14,7 +13,6 @@ export class RequestEntityTooLargeError extends ClientError {
             ...options,
             code: options.code ?? RequestEntityTooLargeErrorOptions.code,
             status: options.status ?? options.statusCode ?? RequestEntityTooLargeErrorOptions.status,
-            statusMessage: options.statusMessage ?? RequestEntityTooLargeErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/414-request-uri-too-long.ts
+++ b/packages/http/src/errors/client/414-request-uri-too-long.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const RequestURITooLongErrorOptions = {
     code: 'REQUEST_URI_TOO_LONG',
     status: 414,
-    statusMessage: 'Request-URI Too Long',
 } as const;
 
 export class RequestURITooLongError extends ClientError {
@@ -14,7 +13,6 @@ export class RequestURITooLongError extends ClientError {
             ...options,
             code: options.code ?? RequestURITooLongErrorOptions.code,
             status: options.status ?? options.statusCode ?? RequestURITooLongErrorOptions.status,
-            statusMessage: options.statusMessage ?? RequestURITooLongErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/415-unsupported-media-type.ts
+++ b/packages/http/src/errors/client/415-unsupported-media-type.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const UnsupportedMediaTypeErrorOptions = {
     code: 'UNSUPPORTED_MEDIA_TYPE',
     status: 415,
-    statusMessage: 'Unsupported Media Type',
 } as const;
 
 export class UnsupportedMediaTypeError extends ClientError {
@@ -14,7 +13,6 @@ export class UnsupportedMediaTypeError extends ClientError {
             ...options,
             code: options.code ?? UnsupportedMediaTypeErrorOptions.code,
             status: options.status ?? options.statusCode ?? UnsupportedMediaTypeErrorOptions.status,
-            statusMessage: options.statusMessage ?? UnsupportedMediaTypeErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/416-requested-range-not-satisfiable.ts
+++ b/packages/http/src/errors/client/416-requested-range-not-satisfiable.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const RequestedRangeNotSatisfiableErrorOptions = {
     code: 'REQUESTED_RANGE_NOT_SATISFIABLE',
     status: 416,
-    statusMessage: 'Requested Range Not Satisfiable',
 } as const;
 
 export class RequestedRangeNotSatisfiableError extends ClientError {
@@ -14,7 +13,6 @@ export class RequestedRangeNotSatisfiableError extends ClientError {
             ...options,
             code: options.code ?? RequestedRangeNotSatisfiableErrorOptions.code,
             status: options.status ?? options.statusCode ?? RequestedRangeNotSatisfiableErrorOptions.status,
-            statusMessage: options.statusMessage ?? RequestedRangeNotSatisfiableErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/417-expectation-failed.ts
+++ b/packages/http/src/errors/client/417-expectation-failed.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const ExpectationFailedErrorOptions = {
     code: 'EXPECTATION_FAILED',
     status: 417,
-    statusMessage: 'Expectation Failed',
 } as const;
 
 export class ExpectationFailedError extends ClientError {
@@ -14,7 +13,6 @@ export class ExpectationFailedError extends ClientError {
             ...options,
             code: options.code ?? ExpectationFailedErrorOptions.code,
             status: options.status ?? options.statusCode ?? ExpectationFailedErrorOptions.status,
-            statusMessage: options.statusMessage ?? ExpectationFailedErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/418-im-a-teapot.ts
+++ b/packages/http/src/errors/client/418-im-a-teapot.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const ImATeapotErrorOptions = {
     code: 'IM_A_TEAPOT',
     status: 418,
-    statusMessage: 'I\'m a Teapot',
 } as const;
 
 export class ImATeapotError extends ClientError {
@@ -14,7 +13,6 @@ export class ImATeapotError extends ClientError {
             ...options,
             code: options.code ?? ImATeapotErrorOptions.code,
             status: options.status ?? options.statusCode ?? ImATeapotErrorOptions.status,
-            statusMessage: options.statusMessage ?? ImATeapotErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/420-enhance-your-calm.ts
+++ b/packages/http/src/errors/client/420-enhance-your-calm.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const EnhanceYourCalmErrorOptions = {
     code: 'ENHANCE_YOUR_CALM',
     status: 420,
-    statusMessage: 'Enhance Your Calm',
 } as const;
 
 export class EnhanceYourCalmError extends ClientError {
@@ -14,7 +13,6 @@ export class EnhanceYourCalmError extends ClientError {
             ...options,
             code: options.code ?? EnhanceYourCalmErrorOptions.code,
             status: options.status ?? options.statusCode ?? EnhanceYourCalmErrorOptions.status,
-            statusMessage: options.statusMessage ?? EnhanceYourCalmErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/422-unprocessable-entity.ts
+++ b/packages/http/src/errors/client/422-unprocessable-entity.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const UnprocessableEntityErrorOptions = {
     code: 'UNPROCESSABLE_ENTITY',
     status: 422,
-    statusMessage: 'Unprocessable Entity',
 } as const;
 
 export class UnprocessableEntityError extends ClientError {
@@ -14,7 +13,6 @@ export class UnprocessableEntityError extends ClientError {
             ...options,
             code: options.code ?? UnprocessableEntityErrorOptions.code,
             status: options.status ?? options.statusCode ?? UnprocessableEntityErrorOptions.status,
-            statusMessage: options.statusMessage ?? UnprocessableEntityErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/423-locked.ts
+++ b/packages/http/src/errors/client/423-locked.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const LockedErrorOptions = {
     code: 'LOCKED',
     status: 423,
-    statusMessage: 'Locked',
 } as const;
 
 export class LockedError extends ClientError {
@@ -14,7 +13,6 @@ export class LockedError extends ClientError {
             ...options,
             code: options.code ?? LockedErrorOptions.code,
             status: options.status ?? options.statusCode ?? LockedErrorOptions.status,
-            statusMessage: options.statusMessage ?? LockedErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/424-failed-dependency.ts
+++ b/packages/http/src/errors/client/424-failed-dependency.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const FailedDependencyErrorOptions = {
     code: 'FAILED_DEPENDENCY',
     status: 424,
-    statusMessage: 'Failed Dependency',
 } as const;
 
 export class FailedDependencyError extends ClientError {
@@ -14,7 +13,6 @@ export class FailedDependencyError extends ClientError {
             ...options,
             code: options.code ?? FailedDependencyErrorOptions.code,
             status: options.status ?? options.statusCode ?? FailedDependencyErrorOptions.status,
-            statusMessage: options.statusMessage ?? FailedDependencyErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/425-unordered-collection.ts
+++ b/packages/http/src/errors/client/425-unordered-collection.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const UnorderedCollectionErrorOptions = {
     code: 'UNORDERED_COLLECTION',
     status: 425,
-    statusMessage: 'Unordered Collection',
 } as const;
 
 export class UnorderedCollectionError extends ClientError {
@@ -14,7 +13,6 @@ export class UnorderedCollectionError extends ClientError {
             ...options,
             code: options.code ?? UnorderedCollectionErrorOptions.code,
             status: options.status ?? options.statusCode ?? UnorderedCollectionErrorOptions.status,
-            statusMessage: options.statusMessage ?? UnorderedCollectionErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/426-upgrade-required.ts
+++ b/packages/http/src/errors/client/426-upgrade-required.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const UpgradeRequiredErrorOptions = {
     code: 'UPGRADE_REQUIRED',
     status: 426,
-    statusMessage: 'Upgrade Required',
 } as const;
 
 export class UpgradeRequiredError extends ClientError {
@@ -14,7 +13,6 @@ export class UpgradeRequiredError extends ClientError {
             ...options,
             code: options.code ?? UpgradeRequiredErrorOptions.code,
             status: options.status ?? options.statusCode ?? UpgradeRequiredErrorOptions.status,
-            statusMessage: options.statusMessage ?? UpgradeRequiredErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/428-precondition-required.ts
+++ b/packages/http/src/errors/client/428-precondition-required.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const PreconditionRequiredErrorOptions = {
     code: 'PRECONDITION_REQUIRED',
     status: 428,
-    statusMessage: 'Precondition Required',
 } as const;
 
 export class PreconditionRequiredError extends ClientError {
@@ -14,7 +13,6 @@ export class PreconditionRequiredError extends ClientError {
             ...options,
             code: options.code ?? PreconditionRequiredErrorOptions.code,
             status: options.status ?? options.statusCode ?? PreconditionRequiredErrorOptions.status,
-            statusMessage: options.statusMessage ?? PreconditionRequiredErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/429-too-many-requests.ts
+++ b/packages/http/src/errors/client/429-too-many-requests.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const TooManyRequestsErrorOptions = {
     code: 'TOO_MANY_REQUESTS',
     status: 429,
-    statusMessage: 'Too Many Requests',
 } as const;
 
 export class TooManyRequestsError extends ClientError {
@@ -14,7 +13,6 @@ export class TooManyRequestsError extends ClientError {
             ...options,
             code: options.code ?? TooManyRequestsErrorOptions.code,
             status: options.status ?? options.statusCode ?? TooManyRequestsErrorOptions.status,
-            statusMessage: options.statusMessage ?? TooManyRequestsErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/431-request-header-fields-too-large.ts
+++ b/packages/http/src/errors/client/431-request-header-fields-too-large.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const RequestHeaderFieldsTooLargeErrorOptions = {
     code: 'REQUEST_HEADER_FIELDS_TOO_LARGE',
     status: 431,
-    statusMessage: 'Request Header Fields Too Large',
 } as const;
 
 export class RequestHeaderFieldsTooLargeError extends ClientError {
@@ -14,7 +13,6 @@ export class RequestHeaderFieldsTooLargeError extends ClientError {
             ...options,
             code: options.code ?? RequestHeaderFieldsTooLargeErrorOptions.code,
             status: options.status ?? options.statusCode ?? RequestHeaderFieldsTooLargeErrorOptions.status,
-            statusMessage: options.statusMessage ?? RequestHeaderFieldsTooLargeErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/444-no-response.ts
+++ b/packages/http/src/errors/client/444-no-response.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const NoResponseErrorOptions = {
     code: 'NO_RESPONSE',
     status: 444,
-    statusMessage: 'No Response',
 } as const;
 
 export class NoResponseError extends ClientError {
@@ -14,7 +13,6 @@ export class NoResponseError extends ClientError {
             ...options,
             code: options.code ?? NoResponseErrorOptions.code,
             status: options.status ?? options.statusCode ?? NoResponseErrorOptions.status,
-            statusMessage: options.statusMessage ?? NoResponseErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/449-retry-with.ts
+++ b/packages/http/src/errors/client/449-retry-with.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const RetryWithErrorOptions = {
     code: 'RETRY_WITH',
     status: 449,
-    statusMessage: 'Retry With',
 } as const;
 
 export class RetryWithError extends ClientError {
@@ -14,7 +13,6 @@ export class RetryWithError extends ClientError {
             ...options,
             code: options.code ?? RetryWithErrorOptions.code,
             status: options.status ?? options.statusCode ?? RetryWithErrorOptions.status,
-            statusMessage: options.statusMessage ?? RetryWithErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/450-blocked-by-windows-parental-controls.ts
+++ b/packages/http/src/errors/client/450-blocked-by-windows-parental-controls.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const BlockedByWindowsParentalControlsErrorOptions = {
     code: 'BLOCKED_BY_WINDOWS_PARENTAL_CONTROLS',
     status: 450,
-    statusMessage: 'Blocked By Windows Parental Controls',
 } as const;
 
 export class BlockedByWindowsParentalControlsError extends ClientError {
@@ -14,7 +13,6 @@ export class BlockedByWindowsParentalControlsError extends ClientError {
             ...options,
             code: options.code ?? BlockedByWindowsParentalControlsErrorOptions.code,
             status: options.status ?? options.statusCode ?? BlockedByWindowsParentalControlsErrorOptions.status,
-            statusMessage: options.statusMessage ?? BlockedByWindowsParentalControlsErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/client/499-client-closed-request.ts
+++ b/packages/http/src/errors/client/499-client-closed-request.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const ClientClosedRequestErrorOptions = {
     code: 'CLIENT_CLOSED_REQUEST',
     status: 499,
-    statusMessage: 'Client Closed Request',
 } as const;
 
 export class ClientClosedRequestError extends ClientError {
@@ -14,7 +13,6 @@ export class ClientClosedRequestError extends ClientError {
             ...options,
             code: options.code ?? ClientClosedRequestErrorOptions.code,
             status: options.status ?? options.statusCode ?? ClientClosedRequestErrorOptions.status,
-            statusMessage: options.statusMessage ?? ClientClosedRequestErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/server/500-internal-server-error.ts
+++ b/packages/http/src/errors/server/500-internal-server-error.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const InternalServerErrorOptions = {
     code: 'INTERNAL_SERVER_ERROR',
     status: 500,
-    statusMessage: 'Internal Server Error',
 } as const;
 
 export class InternalServerError extends ServerError {
@@ -14,7 +13,6 @@ export class InternalServerError extends ServerError {
             ...options,
             code: options.code ?? InternalServerErrorOptions.code,
             status: options.status ?? options.statusCode ?? InternalServerErrorOptions.status,
-            statusMessage: options.statusMessage ?? InternalServerErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/server/501-not-implemented.ts
+++ b/packages/http/src/errors/server/501-not-implemented.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const NotImplementedErrorOptions = {
     code: 'NOT_IMPLEMENTED',
     status: 501,
-    statusMessage: 'Not Implemented',
 } as const;
 
 export class NotImplementedError extends ServerError {
@@ -14,7 +13,6 @@ export class NotImplementedError extends ServerError {
             ...options,
             code: options.code ?? NotImplementedErrorOptions.code,
             status: options.status ?? options.statusCode ?? NotImplementedErrorOptions.status,
-            statusMessage: options.statusMessage ?? NotImplementedErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/server/502-bad-gateway.ts
+++ b/packages/http/src/errors/server/502-bad-gateway.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const BadGatewayErrorOptions = {
     code: 'BAD_GATEWAY',
     status: 502,
-    statusMessage: 'Bad Gateway',
 } as const;
 
 export class BadGatewayError extends ServerError {
@@ -14,7 +13,6 @@ export class BadGatewayError extends ServerError {
             ...options,
             code: options.code ?? BadGatewayErrorOptions.code,
             status: options.status ?? options.statusCode ?? BadGatewayErrorOptions.status,
-            statusMessage: options.statusMessage ?? BadGatewayErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/server/503-service-unavailable.ts
+++ b/packages/http/src/errors/server/503-service-unavailable.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const ServiceUnavailableErrorOptions = {
     code: 'SERVICE_UNAVAILABLE',
     status: 503,
-    statusMessage: 'Service Unavailable',
 } as const;
 
 export class ServiceUnavailableError extends ServerError {
@@ -14,7 +13,6 @@ export class ServiceUnavailableError extends ServerError {
             ...options,
             code: options.code ?? ServiceUnavailableErrorOptions.code,
             status: options.status ?? options.statusCode ?? ServiceUnavailableErrorOptions.status,
-            statusMessage: options.statusMessage ?? ServiceUnavailableErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/server/504-gateway-timeout.ts
+++ b/packages/http/src/errors/server/504-gateway-timeout.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const GatewayTimeoutErrorOptions = {
     code: 'GATEWAY_TIMEOUT',
     status: 504,
-    statusMessage: 'Gateway Timeout',
 } as const;
 
 export class GatewayTimeoutError extends ServerError {
@@ -14,7 +13,6 @@ export class GatewayTimeoutError extends ServerError {
             ...options,
             code: options.code ?? GatewayTimeoutErrorOptions.code,
             status: options.status ?? options.statusCode ?? GatewayTimeoutErrorOptions.status,
-            statusMessage: options.statusMessage ?? GatewayTimeoutErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/server/505-http-version-not-supported.ts
+++ b/packages/http/src/errors/server/505-http-version-not-supported.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const HTTPVersionNotSupportedErrorOptions = {
     code: 'HTTP_VERSION_NOT_SUPPORTED',
     status: 505,
-    statusMessage: 'HTTP Version Not Supported',
 } as const;
 
 export class HTTPVersionNotSupportedError extends ServerError {
@@ -14,7 +13,6 @@ export class HTTPVersionNotSupportedError extends ServerError {
             ...options,
             code: options.code ?? HTTPVersionNotSupportedErrorOptions.code,
             status: options.status ?? options.statusCode ?? HTTPVersionNotSupportedErrorOptions.status,
-            statusMessage: options.statusMessage ?? HTTPVersionNotSupportedErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/server/506-variant-also-negotiates.ts
+++ b/packages/http/src/errors/server/506-variant-also-negotiates.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const VariantAlsoNegotiatesErrorOptions = {
     code: 'VARIANT_ALSO_NEGOTIATES',
     status: 506,
-    statusMessage: 'Variant Also Negotiates',
 } as const;
 
 export class VariantAlsoNegotiatesError extends ServerError {
@@ -14,7 +13,6 @@ export class VariantAlsoNegotiatesError extends ServerError {
             ...options,
             code: options.code ?? VariantAlsoNegotiatesErrorOptions.code,
             status: options.status ?? options.statusCode ?? VariantAlsoNegotiatesErrorOptions.status,
-            statusMessage: options.statusMessage ?? VariantAlsoNegotiatesErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/server/507-insufficient-storage.ts
+++ b/packages/http/src/errors/server/507-insufficient-storage.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const InsufficientStorageErrorOptions = {
     code: 'INSUFFICIENT_STORAGE',
     status: 507,
-    statusMessage: 'Insufficient Storage',
 } as const;
 
 export class InsufficientStorageError extends ServerError {
@@ -14,7 +13,6 @@ export class InsufficientStorageError extends ServerError {
             ...options,
             code: options.code ?? InsufficientStorageErrorOptions.code,
             status: options.status ?? options.statusCode ?? InsufficientStorageErrorOptions.status,
-            statusMessage: options.statusMessage ?? InsufficientStorageErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/server/508-loop-detected.ts
+++ b/packages/http/src/errors/server/508-loop-detected.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const LoopDetectedErrorOptions = {
     code: 'LOOP_DETECTED',
     status: 508,
-    statusMessage: 'Loop Detected',
 } as const;
 
 export class LoopDetectedError extends ServerError {
@@ -14,7 +13,6 @@ export class LoopDetectedError extends ServerError {
             ...options,
             code: options.code ?? LoopDetectedErrorOptions.code,
             status: options.status ?? options.statusCode ?? LoopDetectedErrorOptions.status,
-            statusMessage: options.statusMessage ?? LoopDetectedErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/server/509-bandwidth-limit-exceeded.ts
+++ b/packages/http/src/errors/server/509-bandwidth-limit-exceeded.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const BandwidthLimitExceededErrorOptions = {
     code: 'BANDWIDTH_LIMIT_EXCEEDED',
     status: 509,
-    statusMessage: 'Bandwidth Limit Exceeded',
 } as const;
 
 export class BandwidthLimitExceededError extends ServerError {
@@ -14,7 +13,6 @@ export class BandwidthLimitExceededError extends ServerError {
             ...options,
             code: options.code ?? BandwidthLimitExceededErrorOptions.code,
             status: options.status ?? options.statusCode ?? BandwidthLimitExceededErrorOptions.status,
-            statusMessage: options.statusMessage ?? BandwidthLimitExceededErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/server/510-not-extended.ts
+++ b/packages/http/src/errors/server/510-not-extended.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const NotExtendedErrorOptions = {
     code: 'NOT_EXTENDED',
     status: 510,
-    statusMessage: 'Not Extended',
 } as const;
 
 export class NotExtendedError extends ServerError {
@@ -14,7 +13,6 @@ export class NotExtendedError extends ServerError {
             ...options,
             code: options.code ?? NotExtendedErrorOptions.code,
             status: options.status ?? options.statusCode ?? NotExtendedErrorOptions.status,
-            statusMessage: options.statusMessage ?? NotExtendedErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/errors/server/511-network-authentication-required.ts
+++ b/packages/http/src/errors/server/511-network-authentication-required.ts
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const NetworkAuthenticationRequiredErrorOptions = {
     code: 'NETWORK_AUTHENTICATION_REQUIRED',
     status: 511,
-    statusMessage: 'Network Authentication Required',
 } as const;
 
 export class NetworkAuthenticationRequiredError extends ServerError {
@@ -14,7 +13,6 @@ export class NetworkAuthenticationRequiredError extends ServerError {
             ...options,
             code: options.code ?? NetworkAuthenticationRequiredErrorOptions.code,
             status: options.status ?? options.statusCode ?? NetworkAuthenticationRequiredErrorOptions.status,
-            statusMessage: options.statusMessage ?? NetworkAuthenticationRequiredErrorOptions.statusMessage,
         });
     }
 }

--- a/packages/http/src/types.ts
+++ b/packages/http/src/types.ts
@@ -14,11 +14,6 @@ export type HTTPErrorOptions = BaseErrorOptions & {
     statusCode?: number | string,
 
     /**
-     * A status message.
-     */
-    statusMessage?: string,
-
-    /**
      * Specify a redirect URL in case of a http error.
      */
     redirectURL?: string

--- a/packages/http/src/utils/options.ts
+++ b/packages/http/src/utils/options.ts
@@ -22,13 +22,6 @@ export function isHTTPErrorOptions(input: unknown) : input is HTTPErrorOptions {
         return false;
     }
 
-    if (
-        typeof input.statusMessage !== 'undefined' &&
-        typeof input.statusMessage !== 'string'
-    ) {
-        return false;
-    }
-
     return typeof input.redirectURL === 'undefined' ||
         typeof input.redirectURL === 'string';
 }

--- a/packages/http/src/utils/sanitize.ts
+++ b/packages/http/src/utils/sanitize.ts
@@ -1,13 +1,3 @@
-// ASCII printable characters only (0x20 space through 0x7E tilde)
- 
-const pattern = /[^\x20-\x7E]/g;
-
-const MAX_STATUS_MESSAGE_LENGTH = 256;
-
-export function sanitizeStatusMessage(input: string) {
-    return input.replace(pattern, '').trim().slice(0, MAX_STATUS_MESSAGE_LENGTH);
-}
-
 export function sanitizeStatusCode(input: string | number) {
     const code = Number.parseInt(`${input}`, 10);
 

--- a/packages/http/src/utils/sanitize.ts
+++ b/packages/http/src/utils/sanitize.ts
@@ -1,7 +1,11 @@
-export function sanitizeStatusCode(input: string | number) {
+export function sanitizeStatusCode(input?: string | number | null) {
+    if (input === null || typeof input === 'undefined') {
+        return 500;
+    }
+
     const code = Number.parseInt(`${input}`, 10);
 
-    if (!Number.isInteger(code) || code < 100 || code > 599) {
+    if (!Number.isInteger(code) || code < 400 || code > 599) {
         return 500;
     }
 

--- a/packages/http/template/error.tpl
+++ b/packages/http/template/error.tpl
@@ -4,7 +4,6 @@ import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 export const {{{class}}}Options = {
     code: '{{code}}',
     status: {{statusCode}},
-    statusMessage: '{{{statusMessage}}}',
 } as const;
 
 export class {{{class}}} extends {{baseClass}} {
@@ -14,7 +13,6 @@ export class {{{class}}} extends {{baseClass}} {
             ...options,
             code: options.code ?? {{{class}}}Options.code,
             status: options.status ?? options.statusCode ?? {{{class}}}Options.status,
-            statusMessage: options.statusMessage ?? {{{class}}}Options.statusMessage,
         });
     }
 }

--- a/packages/http/test/unit/module.spec.ts
+++ b/packages/http/test/unit/module.spec.ts
@@ -108,13 +108,14 @@ describe('src/module.ts', () => {
         expect(isHTTPError(t2)).toBeTruthy();
     });
 
-    it('should not recognize http error', () => {
+    it('should normalize non-error status to 500', () => {
         const error = new HTTPError({ statusCode: 300 });
+        expect(error.status).toEqual(500);
+        expect(isServerError(error)).toBeTruthy();
+        expect(isHTTPError(error)).toBeTruthy();
+    });
 
-        expect(isClientError(error)).toBeFalsy();
-        expect(isServerError(error)).toBeFalsy();
-        expect(isHTTPError(error)).toBeFalsy();
-
+    it('should not recognize non-HTTPError as http error', () => {
         expect(isHTTPError(undefined)).toBeFalsy();
     });
 });

--- a/packages/http/test/unit/module.spec.ts
+++ b/packages/http/test/unit/module.spec.ts
@@ -19,23 +19,48 @@ describe('src/module.ts', () => {
     });
 
     it('should create instance with options', () => {
-        const error = new HTTPError({
-            statusCode: 490,
-            statusMessage: 'Foo bar',
-        });
+        const error = new HTTPError({ statusCode: 490 });
         expect(error.status).toEqual(490);
         expect(error.statusCode).toEqual(490);
-        expect(error.statusMessage).toEqual('Foo bar');
     });
 
     it('should create instance with status option', () => {
-        const error = new HTTPError({
-            status: 490,
-            statusMessage: 'Foo bar',
-        });
+        const error = new HTTPError({ status: 490 });
         expect(error.status).toEqual(490);
         expect(error.statusCode).toEqual(490);
-        expect(error.statusMessage).toEqual('Foo bar');
+    });
+
+    it('should default message to status text when no message provided', () => {
+        const error = new HTTPError({ status: 404 });
+        expect(error.message).toEqual('Not Found');
+    });
+
+    it('should preserve explicit message', () => {
+        const error = new HTTPError({ status: 404, message: 'User not found' });
+        expect(error.message).toEqual('User not found');
+    });
+
+    it('should fall back to default message for unknown status code', () => {
+        const error = new HTTPError({ status: 490 });
+        expect(error.message).toEqual('An error occurred');
+    });
+
+    it('should derive statusMessage from status code', () => {
+        const error = new HTTPError({ status: 404 });
+        expect(error.statusMessage).toEqual('Not Found');
+    });
+
+    it('should return undefined statusMessage for unknown status code', () => {
+        const error = new HTTPError({ status: 490 });
+        expect(error.statusMessage).toBeUndefined();
+    });
+
+    it('should cache statusMessage on repeated access', () => {
+        const error = new HTTPError({ status: 500 });
+        const first = error.statusMessage;
+        const second = error.statusMessage;
+        expect(first).toEqual('Internal Server Error');
+        expect(first).toBe(second);
     });
 
     it('should prefer status over deprecated statusCode when both are provided', () => {
@@ -64,38 +89,13 @@ describe('src/module.ts', () => {
         expect(error.statusCode).toEqual(422);
     });
 
-    it('should sanitize status message to ASCII only', () => {
-        const error = new HTTPError({
-            statusCode: 400,
-            statusMessage: 'Bad\u00A0Request\u200B',
-        });
-        expect(error.statusMessage).toEqual('BadRequest');
-    });
-
-    it('should strip CRLF from status message to prevent response splitting', () => {
-        const error = new HTTPError({
-            statusCode: 400,
-            statusMessage: 'OK\r\nSet-Cookie: admin=true',
-        });
-        expect(error.statusMessage).toEqual('OKSet-Cookie: admin=true');
-    });
-
-    it('should strip lone CR and LF from status message', () => {
-        const error = new HTTPError({
-            statusCode: 400,
-            statusMessage: 'Bad\rRequest\nHere',
-        });
-        expect(error.statusMessage).toEqual('BadRequestHere');
-    });
-
-    it('should trim and cap status message length', () => {
-        const longMessage = 'A'.repeat(300);
-        const error = new HTTPError({
-            statusCode: 400,
-            statusMessage: `  ${longMessage}  `,
-        });
-        expect(error.statusMessage!.length).toBeLessThanOrEqual(256);
-        expect(error.statusMessage).toEqual('A'.repeat(256));
+    it('should include status and statusMessage in toJSON', () => {
+        const error = new NotFoundError('User not found');
+        const json = error.toJSON();
+        expect(json.status).toEqual(404);
+        expect(json.statusMessage).toEqual('Not Found');
+        expect(json.message).toEqual('User not found');
+        expect(json.code).toEqual('NOT_FOUND');
     });
 
     it('should recognize client error', () => {

--- a/packages/http/test/unit/module.spec.ts
+++ b/packages/http/test/unit/module.spec.ts
@@ -45,24 +45,6 @@ describe('src/module.ts', () => {
         expect(error.message).toEqual('An error occurred');
     });
 
-    it('should derive statusMessage from status code', () => {
-        const error = new HTTPError({ status: 404 });
-        expect(error.statusMessage).toEqual('Not Found');
-    });
-
-    it('should return undefined statusMessage for unknown status code', () => {
-        const error = new HTTPError({ status: 490 });
-        expect(error.statusMessage).toBeUndefined();
-    });
-
-    it('should cache statusMessage on repeated access', () => {
-        const error = new HTTPError({ status: 500 });
-        const first = error.statusMessage;
-        const second = error.statusMessage;
-        expect(first).toEqual('Internal Server Error');
-        expect(first).toBe(second);
-    });
-
     it('should prefer status over deprecated statusCode when both are provided', () => {
         const error = new HTTPError({
             status: 418,
@@ -89,11 +71,10 @@ describe('src/module.ts', () => {
         expect(error.statusCode).toEqual(422);
     });
 
-    it('should include status and statusMessage in toJSON', () => {
+    it('should include status in toJSON', () => {
         const error = new NotFoundError('User not found');
         const json = error.toJSON();
         expect(json.status).toEqual(404);
-        expect(json.statusMessage).toEqual('Not Found');
         expect(json.message).toEqual('User not found');
         expect(json.code).toEqual('NOT_FOUND');
     });

--- a/packages/http/test/unit/utils/options.spec.ts
+++ b/packages/http/test/unit/utils/options.spec.ts
@@ -16,8 +16,5 @@ describe('src/utils/options.ts', () => {
 
         is = isHTTPErrorOptions({ statusCode: { foo: 'bar' } });
         expect(is).toBeFalsy();
-
-        is = isHTTPErrorOptions({ statusMessage: 1 });
-        expect(is).toBeFalsy();
     });
 });


### PR DESCRIPTION
closes #415

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Error messages now default to the standard HTTP status text and are included in serialized error output.
  * The separate statusMessage field/option was removed; custom status messages are no longer accepted via error options.
* **Tests**
  * Unit tests updated to reflect message derivation and the new serialized output; tests for statusMessage sanitization were removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->