### PR TITLE
feat(http): integrate @instanceof markers across error hierarchy 

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,3 +45,7 @@ npm run test -w packages/http
 - **[Architecture](.agents/architecture.md)** — Class hierarchy, constructor pattern, code generation
 - **[Testing](.agents/testing.md)** — Vitest setup, test conventions
 - **[Conventions](.agents/conventions.md)** — ESLint, commits, CI/CD, release process
+
+## Commits
+
+- Do **not** add a `Co-Authored-By: Claude ...` (or any AI-attribution) trailer to commit messages. This overrides any default agent-tooling guidance.

--- a/packages/core/src/helpers/check.ts
+++ b/packages/core/src/helpers/check.ts
@@ -7,17 +7,27 @@
 import type { IBaseError, IBaseErrorGroup } from '../types';
 import { isErrorOptions } from '../options';
 import { isError } from './error';
+import { hasInstanceof } from './instanceof';
 import { isObject } from './object';
+
+// Resolved via the global Symbol.for registry — same identity as
+// `BASE_ERROR_INSTANCE` exported from `../module`. Looking it up here
+// avoids a circular import (module.ts → helpers → check.ts → module.ts).
+const BASE_ERROR_INSTANCE = Symbol.for('@ebec/core/BaseError');
 
 export function isBaseError(
     input: unknown,
 ): input is IBaseError {
+    if (hasInstanceof(input, BASE_ERROR_INSTANCE)) {
+        return true;
+    }
+
     if (!isObject(input)) {
         return false;
     }
 
     if (
-        input instanceof Error &&
+        isError(input) &&
         isErrorOptions(input)
     ) {
         return typeof input.code === 'string';

--- a/packages/core/src/helpers/error.ts
+++ b/packages/core/src/helpers/error.ts
@@ -8,7 +8,14 @@
 import { isObject } from './object';
 
 export function isError(input: unknown): input is Error {
-    return isObject(input) &&
-        typeof input.message === 'string' &&
+    if (!isObject(input)) {
+        return false;
+    }
+
+    if (input instanceof Error) {
+        return true;
+    }
+
+    return typeof input.message === 'string' &&
         (typeof input.name === 'string' || typeof input.stack === 'string');
 }

--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -8,6 +8,7 @@
 export * from './check';
 export * from './error';
 export * from './error-code';
+export * from './instanceof';
 export * from './interpolate';
 export * from './object';
 export * from './sanitize-code';

--- a/packages/core/src/helpers/instanceof.ts
+++ b/packages/core/src/helpers/instanceof.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026.
+ *  Author Peter Placzek (tada5hi)
+ *  For the full copyright and license information,
+ *  view the LICENSE file that was distributed with this source code.
+ */
+
+import { isObject } from './object';
+
+/**
+ * Property name used to store the cross-realm class-marker chain on instances.
+ *
+ * The chain is a `symbol[]` of `Symbol.for(...)` markers — one per class in the
+ * inheritance path. Stored as a non-enumerable, non-writable, non-configurable
+ * property so it stays out of `Object.keys()` and `JSON.stringify()` output.
+ */
+export const INSTANCEOF_PROPERTY = '@instanceof' as const;
+
+/**
+ * Append a class-marker symbol to the receiver's `@instanceof` chain.
+ *
+ * Each error class declares a `Symbol.for(...)` marker for itself and calls
+ * `markInstanceof(this, MY_MARKER)` from its constructor. Subclass instances
+ * accumulate markers from every ancestor in the chain, so a parent-class
+ * guard can fast-path-match a subclass instance.
+ *
+ * Idempotent — re-marking the same instance with the same symbol is a no-op.
+ */
+export function markInstanceof(target: object, marker: symbol): void {
+    const existing = (target as Record<string, unknown>)[INSTANCEOF_PROPERTY];
+    if (Array.isArray(existing)) {
+        if (!existing.includes(marker)) {
+            existing.push(marker);
+        }
+        return;
+    }
+
+    Object.defineProperty(target, INSTANCEOF_PROPERTY, {
+        value: [marker],
+        writable: false,
+        enumerable: false,
+        configurable: false,
+    });
+}
+
+/**
+ * Check whether the input's `@instanceof` chain contains `marker`.
+ *
+ * Returns `false` for non-objects, objects without the chain, or chains
+ * stored as a non-array value (defensive).
+ */
+export function hasInstanceof(input: unknown, marker: symbol): boolean {
+    if (!isObject(input)) {
+        return false;
+    }
+
+    const chain = input[INSTANCEOF_PROPERTY];
+    return Array.isArray(chain) && chain.includes(marker);
+}

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -6,8 +6,15 @@
  */
 
 import type { ErrorInput, IBaseError } from './types';
-import { interpolate, sanitizeErrorCode, toSerializable } from './helpers';
+import {
+    interpolate,
+    markInstanceof,
+    sanitizeErrorCode,
+    toSerializable,
+} from './helpers';
 import { extractErrorOptions } from './options';
+
+export const BASE_ERROR_INSTANCE = Symbol.for('@ebec/core/BaseError');
 
 export class BaseError extends Error implements IBaseError {
     /**
@@ -64,6 +71,8 @@ export class BaseError extends Error implements IBaseError {
         if (options.errors !== undefined) {
             this.errors = [...options.errors];
         }
+
+        markInstanceof(this, BASE_ERROR_INSTANCE);
     }
 
     toJSON(): {

--- a/packages/core/test/unit/instanceof.spec.ts
+++ b/packages/core/test/unit/instanceof.spec.ts
@@ -1,0 +1,201 @@
+/* eslint-disable max-classes-per-file */
+import { describe, expect, it } from 'vitest';
+import {
+    BASE_ERROR_INSTANCE,
+    BaseError,
+    INSTANCEOF_PROPERTY,
+    hasInstanceof,
+    isBaseError,
+    markInstanceof,
+} from '../../src';
+
+describe('src/helpers/instanceof.ts', () => {
+    describe('markInstanceof', () => {
+        it('should attach the marker chain on first call', () => {
+            const target = {};
+            const marker = Symbol.for('@ebec-test/Foo');
+
+            markInstanceof(target, marker);
+
+            const chain = (target as Record<string, unknown>)[INSTANCEOF_PROPERTY];
+            expect(Array.isArray(chain)).toBe(true);
+            expect(chain).toEqual([marker]);
+        });
+
+        it('should append additional markers to the existing chain', () => {
+            const target = {};
+            const fooMarker = Symbol.for('@ebec-test/Foo');
+            const barMarker = Symbol.for('@ebec-test/Bar');
+
+            markInstanceof(target, fooMarker);
+            markInstanceof(target, barMarker);
+
+            const chain = (target as Record<string, unknown>)[INSTANCEOF_PROPERTY];
+            expect(chain).toEqual([fooMarker, barMarker]);
+        });
+
+        it('should be idempotent for the same marker', () => {
+            const target = {};
+            const marker = Symbol.for('@ebec-test/Foo');
+
+            markInstanceof(target, marker);
+            markInstanceof(target, marker);
+            markInstanceof(target, marker);
+
+            const chain = (target as Record<string, unknown>)[INSTANCEOF_PROPERTY];
+            expect(chain).toEqual([marker]);
+        });
+
+        it('should install a non-enumerable, non-writable, non-configurable property', () => {
+            const target = {};
+            const marker = Symbol.for('@ebec-test/Descriptor');
+
+            markInstanceof(target, marker);
+
+            const descriptor = Object.getOwnPropertyDescriptor(target, INSTANCEOF_PROPERTY);
+            expect(descriptor).toBeDefined();
+            expect(descriptor?.enumerable).toBe(false);
+            expect(descriptor?.writable).toBe(false);
+            expect(descriptor?.configurable).toBe(false);
+        });
+
+        it('should keep the chain out of JSON.stringify output', () => {
+            const target: Record<string, unknown> = { foo: 1 };
+            const marker = Symbol.for('@ebec-test/Json');
+
+            markInstanceof(target, marker);
+
+            expect(JSON.stringify(target)).toEqual('{"foo":1}');
+            expect(Object.keys(target)).toEqual(['foo']);
+        });
+    });
+
+    describe('hasInstanceof', () => {
+        it('should match a marker present in the chain', () => {
+            const target = {};
+            const marker = Symbol.for('@ebec-test/Hit');
+
+            markInstanceof(target, marker);
+
+            expect(hasInstanceof(target, marker)).toBe(true);
+        });
+
+        it('should not match a marker absent from the chain', () => {
+            const target = {};
+            const present = Symbol.for('@ebec-test/Present');
+            const absent = Symbol.for('@ebec-test/Absent');
+
+            markInstanceof(target, present);
+
+            expect(hasInstanceof(target, absent)).toBe(false);
+        });
+
+        it('should return false for objects without the chain', () => {
+            expect(hasInstanceof({}, Symbol.for('@ebec-test/None'))).toBe(false);
+        });
+
+        it('should return false for non-object inputs', () => {
+            const marker = Symbol.for('@ebec-test/NonObject');
+
+            expect(hasInstanceof(undefined, marker)).toBe(false);
+            expect(hasInstanceof(null, marker)).toBe(false);
+            expect(hasInstanceof('string', marker)).toBe(false);
+            expect(hasInstanceof(42, marker)).toBe(false);
+            expect(hasInstanceof(true, marker)).toBe(false);
+        });
+
+        it('should return false defensively when the chain is not an array', () => {
+            const target = { [INSTANCEOF_PROPERTY]: 'not-an-array' };
+            const marker = Symbol.for('@ebec-test/Defensive');
+
+            expect(hasInstanceof(target, marker)).toBe(false);
+        });
+    });
+
+    describe('cross-realm identity via Symbol.for', () => {
+        it('should match across independent Symbol.for lookups for the same key', () => {
+            const target = {};
+
+            markInstanceof(target, Symbol.for('@ebec-test/CrossRealm'));
+
+            // Simulate a check from another bundle / realm — a fresh Symbol.for
+            // lookup with the same key resolves to the identical symbol.
+            expect(hasInstanceof(target, Symbol.for('@ebec-test/CrossRealm'))).toBe(true);
+        });
+
+        it('should not match unrelated Symbol() instances with the same description', () => {
+            const target = {};
+
+            markInstanceof(target, Symbol.for('@ebec-test/Local'));
+
+            // A locally-scoped Symbol() with the same description is a
+            // different identity and must not collide with the global one.
+            expect(hasInstanceof(target, Symbol('@ebec-test/Local'))).toBe(false);
+        });
+    });
+
+    describe('BaseError self-marking', () => {
+        it('should attach BASE_ERROR_INSTANCE to every BaseError instance', () => {
+            const error = new BaseError('boom');
+
+            expect(hasInstanceof(error, BASE_ERROR_INSTANCE)).toBe(true);
+        });
+
+        it('should resolve BASE_ERROR_INSTANCE via Symbol.for across lookups', () => {
+            const error = new BaseError();
+
+            expect(hasInstanceof(error, Symbol.for('@ebec/core/BaseError'))).toBe(true);
+        });
+
+        it('should let isBaseError fast-path-match a marker-only foreign object', () => {
+            const foreign: Record<string, unknown> = {};
+            Object.defineProperty(foreign, INSTANCEOF_PROPERTY, {
+                value: [BASE_ERROR_INSTANCE],
+                enumerable: false,
+            });
+
+            expect(isBaseError(foreign)).toBe(true);
+        });
+    });
+
+    describe('inheritance chain accumulation', () => {
+        const FOO_INSTANCE = Symbol.for('@ebec-test/FooError');
+        const BAR_INSTANCE = Symbol.for('@ebec-test/BarError');
+
+        class FooError extends BaseError {
+            constructor(input?: ConstructorParameters<typeof BaseError>[0]) {
+                super(input);
+                markInstanceof(this, FOO_INSTANCE);
+            }
+        }
+
+        class BarError extends FooError {
+            constructor(input?: ConstructorParameters<typeof BaseError>[0]) {
+                super(input);
+                markInstanceof(this, BAR_INSTANCE);
+            }
+        }
+
+        it('should accumulate markers from every ancestor in the chain', () => {
+            const bar = new BarError();
+            const chain = (bar as unknown as Record<string, unknown>)[INSTANCEOF_PROPERTY];
+
+            // BaseError self-marks first, then each subclass appends after super().
+            expect(chain).toEqual([BASE_ERROR_INSTANCE, FOO_INSTANCE, BAR_INSTANCE]);
+        });
+
+        it('should let a parent-class guard fast-path-match a subclass instance', () => {
+            const bar = new BarError();
+
+            expect(hasInstanceof(bar, FOO_INSTANCE)).toBe(true);
+            expect(hasInstanceof(bar, BAR_INSTANCE)).toBe(true);
+        });
+
+        it('should not flag a parent instance with a child marker', () => {
+            const foo = new FooError();
+
+            expect(hasInstanceof(foo, FOO_INSTANCE)).toBe(true);
+            expect(hasInstanceof(foo, BAR_INSTANCE)).toBe(false);
+        });
+    });
+});

--- a/packages/http/build/index.mjs
+++ b/packages/http/build/index.mjs
@@ -75,10 +75,13 @@ function normalizeEntry(key, value) {
 
         const baseClassName = isServerError ? 'ServerError' : 'ClientError';
 
+        const instanceConstantName = `${deriveCode(className)}_INSTANCE`;
+
         const content = mustache.render(tpl, {
             namespaceFile: 'index.ts',
             class: className,
             baseClass: baseClassName,
+            instanceConstantName,
             ...entry,
         });
 

--- a/packages/http/src/errors/base/client.ts
+++ b/packages/http/src/errors/base/client.ts
@@ -1,14 +1,22 @@
+import { hasInstanceof, markInstanceof } from '@ebec/core';
 import type { HTTPErrorInput } from '../../types';
 import { HTTPError, isHTTPError } from './http';
 import type { IClientError } from './types';
 
+export const CLIENT_ERROR_INSTANCE = Symbol.for('@ebec/http/ClientError');
+
 export class ClientError extends HTTPError implements IClientError {
     constructor(input: HTTPErrorInput = {}) {
         super(input);
+        markInstanceof(this, CLIENT_ERROR_INSTANCE);
     }
 }
 
 export function isClientError(input: unknown): input is IClientError {
+    if (hasInstanceof(input, CLIENT_ERROR_INSTANCE)) {
+        return true;
+    }
+
     if (!isHTTPError(input)) {
         return false;
     }

--- a/packages/http/src/errors/base/http.ts
+++ b/packages/http/src/errors/base/http.ts
@@ -1,4 +1,9 @@
-import { BaseError, isBaseError } from '@ebec/core';
+import {
+    BaseError,
+    hasInstanceof,
+    isBaseError,
+    markInstanceof,
+} from '@ebec/core';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 import {
     getStatusText,
@@ -6,6 +11,8 @@ import {
     sanitizeStatusCode,
 } from '../../utils';
 import type { IHTTPError } from './types';
+
+export const HTTP_ERROR_INSTANCE = Symbol.for('@ebec/http/HTTPError');
 
 export class HTTPError extends BaseError implements IHTTPError {
     /**
@@ -30,6 +37,8 @@ export class HTTPError extends BaseError implements IHTTPError {
         this.status = statusCodeNormalized;
 
         this.redirectURL = options.redirectURL;
+
+        markInstanceof(this, HTTP_ERROR_INSTANCE);
     }
 
     /**
@@ -48,6 +57,10 @@ export class HTTPError extends BaseError implements IHTTPError {
 }
 
 export function isHTTPError(input: unknown): input is IHTTPError {
+    if (hasInstanceof(input, HTTP_ERROR_INSTANCE)) {
+        return true;
+    }
+
     if (!isHTTPErrorOptions(input)) {
         return false;
     }

--- a/packages/http/src/errors/base/server.ts
+++ b/packages/http/src/errors/base/server.ts
@@ -1,14 +1,22 @@
+import { hasInstanceof, markInstanceof } from '@ebec/core';
 import type { HTTPErrorInput } from '../../types';
 import { HTTPError, isHTTPError } from './http';
 import type { IServerError } from './types';
 
+export const SERVER_ERROR_INSTANCE = Symbol.for('@ebec/http/ServerError');
+
 export class ServerError extends HTTPError implements IServerError {
     constructor(input: HTTPErrorInput = {}) {
         super(input);
+        markInstanceof(this, SERVER_ERROR_INSTANCE);
     }
 }
 
 export function isServerError(input: unknown): input is IServerError {
+    if (hasInstanceof(input, SERVER_ERROR_INSTANCE)) {
+        return true;
+    }
+
     if (!isHTTPError(input)) {
         return false;
     }

--- a/packages/http/src/errors/client/400-bad-request.ts
+++ b/packages/http/src/errors/client/400-bad-request.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const BAD_REQUEST_ERROR_INSTANCE = Symbol.for('@ebec/http/BadRequestError');
 
 export const BadRequestErrorOptions = {
     code: 'BAD_REQUEST',
@@ -14,5 +17,6 @@ export class BadRequestError extends ClientError {
             code: options.code ?? BadRequestErrorOptions.code,
             status: options.status ?? options.statusCode ?? BadRequestErrorOptions.status,
         });
+        markInstanceof(this, BAD_REQUEST_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/401-unauthorized.ts
+++ b/packages/http/src/errors/client/401-unauthorized.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const UNAUTHORIZED_ERROR_INSTANCE = Symbol.for('@ebec/http/UnauthorizedError');
 
 export const UnauthorizedErrorOptions = {
     code: 'UNAUTHORIZED',
@@ -14,5 +17,6 @@ export class UnauthorizedError extends ClientError {
             code: options.code ?? UnauthorizedErrorOptions.code,
             status: options.status ?? options.statusCode ?? UnauthorizedErrorOptions.status,
         });
+        markInstanceof(this, UNAUTHORIZED_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/403-forbidden.ts
+++ b/packages/http/src/errors/client/403-forbidden.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const FORBIDDEN_ERROR_INSTANCE = Symbol.for('@ebec/http/ForbiddenError');
 
 export const ForbiddenErrorOptions = {
     code: 'FORBIDDEN',
@@ -14,5 +17,6 @@ export class ForbiddenError extends ClientError {
             code: options.code ?? ForbiddenErrorOptions.code,
             status: options.status ?? options.statusCode ?? ForbiddenErrorOptions.status,
         });
+        markInstanceof(this, FORBIDDEN_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/404-not-found.ts
+++ b/packages/http/src/errors/client/404-not-found.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const NOT_FOUND_ERROR_INSTANCE = Symbol.for('@ebec/http/NotFoundError');
 
 export const NotFoundErrorOptions = {
     code: 'NOT_FOUND',
@@ -14,5 +17,6 @@ export class NotFoundError extends ClientError {
             code: options.code ?? NotFoundErrorOptions.code,
             status: options.status ?? options.statusCode ?? NotFoundErrorOptions.status,
         });
+        markInstanceof(this, NOT_FOUND_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/405-method-not-allowed.ts
+++ b/packages/http/src/errors/client/405-method-not-allowed.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const METHOD_NOT_ALLOWED_ERROR_INSTANCE = Symbol.for('@ebec/http/MethodNotAllowedError');
 
 export const MethodNotAllowedErrorOptions = {
     code: 'METHOD_NOT_ALLOWED',
@@ -14,5 +17,6 @@ export class MethodNotAllowedError extends ClientError {
             code: options.code ?? MethodNotAllowedErrorOptions.code,
             status: options.status ?? options.statusCode ?? MethodNotAllowedErrorOptions.status,
         });
+        markInstanceof(this, METHOD_NOT_ALLOWED_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/406-not-acceptable.ts
+++ b/packages/http/src/errors/client/406-not-acceptable.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const NOT_ACCEPTABLE_ERROR_INSTANCE = Symbol.for('@ebec/http/NotAcceptableError');
 
 export const NotAcceptableErrorOptions = {
     code: 'NOT_ACCEPTABLE',
@@ -14,5 +17,6 @@ export class NotAcceptableError extends ClientError {
             code: options.code ?? NotAcceptableErrorOptions.code,
             status: options.status ?? options.statusCode ?? NotAcceptableErrorOptions.status,
         });
+        markInstanceof(this, NOT_ACCEPTABLE_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/407-proxy-authentication-required.ts
+++ b/packages/http/src/errors/client/407-proxy-authentication-required.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const PROXY_AUTHENTICATION_REQUIRED_ERROR_INSTANCE = Symbol.for('@ebec/http/ProxyAuthenticationRequiredError');
 
 export const ProxyAuthenticationRequiredErrorOptions = {
     code: 'PROXY_AUTHENTICATION_REQUIRED',
@@ -14,5 +17,6 @@ export class ProxyAuthenticationRequiredError extends ClientError {
             code: options.code ?? ProxyAuthenticationRequiredErrorOptions.code,
             status: options.status ?? options.statusCode ?? ProxyAuthenticationRequiredErrorOptions.status,
         });
+        markInstanceof(this, PROXY_AUTHENTICATION_REQUIRED_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/408-request-timeout.ts
+++ b/packages/http/src/errors/client/408-request-timeout.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const REQUEST_TIMEOUT_ERROR_INSTANCE = Symbol.for('@ebec/http/RequestTimeoutError');
 
 export const RequestTimeoutErrorOptions = {
     code: 'REQUEST_TIMEOUT',
@@ -14,5 +17,6 @@ export class RequestTimeoutError extends ClientError {
             code: options.code ?? RequestTimeoutErrorOptions.code,
             status: options.status ?? options.statusCode ?? RequestTimeoutErrorOptions.status,
         });
+        markInstanceof(this, REQUEST_TIMEOUT_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/409-conflict.ts
+++ b/packages/http/src/errors/client/409-conflict.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const CONFLICT_ERROR_INSTANCE = Symbol.for('@ebec/http/ConflictError');
 
 export const ConflictErrorOptions = {
     code: 'CONFLICT',
@@ -14,5 +17,6 @@ export class ConflictError extends ClientError {
             code: options.code ?? ConflictErrorOptions.code,
             status: options.status ?? options.statusCode ?? ConflictErrorOptions.status,
         });
+        markInstanceof(this, CONFLICT_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/410-gone.ts
+++ b/packages/http/src/errors/client/410-gone.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const GONE_ERROR_INSTANCE = Symbol.for('@ebec/http/GoneError');
 
 export const GoneErrorOptions = {
     code: 'GONE',
@@ -14,5 +17,6 @@ export class GoneError extends ClientError {
             code: options.code ?? GoneErrorOptions.code,
             status: options.status ?? options.statusCode ?? GoneErrorOptions.status,
         });
+        markInstanceof(this, GONE_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/411-length-required.ts
+++ b/packages/http/src/errors/client/411-length-required.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const LENGTH_REQUIRED_ERROR_INSTANCE = Symbol.for('@ebec/http/LengthRequiredError');
 
 export const LengthRequiredErrorOptions = {
     code: 'LENGTH_REQUIRED',
@@ -14,5 +17,6 @@ export class LengthRequiredError extends ClientError {
             code: options.code ?? LengthRequiredErrorOptions.code,
             status: options.status ?? options.statusCode ?? LengthRequiredErrorOptions.status,
         });
+        markInstanceof(this, LENGTH_REQUIRED_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/412-precondition-failed.ts
+++ b/packages/http/src/errors/client/412-precondition-failed.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const PRECONDITION_FAILED_ERROR_INSTANCE = Symbol.for('@ebec/http/PreconditionFailedError');
 
 export const PreconditionFailedErrorOptions = {
     code: 'PRECONDITION_FAILED',
@@ -14,5 +17,6 @@ export class PreconditionFailedError extends ClientError {
             code: options.code ?? PreconditionFailedErrorOptions.code,
             status: options.status ?? options.statusCode ?? PreconditionFailedErrorOptions.status,
         });
+        markInstanceof(this, PRECONDITION_FAILED_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/413-request-entity-too-large.ts
+++ b/packages/http/src/errors/client/413-request-entity-too-large.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const REQUEST_ENTITY_TOO_LARGE_ERROR_INSTANCE = Symbol.for('@ebec/http/RequestEntityTooLargeError');
 
 export const RequestEntityTooLargeErrorOptions = {
     code: 'REQUEST_ENTITY_TOO_LARGE',
@@ -14,5 +17,6 @@ export class RequestEntityTooLargeError extends ClientError {
             code: options.code ?? RequestEntityTooLargeErrorOptions.code,
             status: options.status ?? options.statusCode ?? RequestEntityTooLargeErrorOptions.status,
         });
+        markInstanceof(this, REQUEST_ENTITY_TOO_LARGE_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/414-request-uri-too-long.ts
+++ b/packages/http/src/errors/client/414-request-uri-too-long.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const REQUEST_URI_TOO_LONG_ERROR_INSTANCE = Symbol.for('@ebec/http/RequestURITooLongError');
 
 export const RequestURITooLongErrorOptions = {
     code: 'REQUEST_URI_TOO_LONG',
@@ -14,5 +17,6 @@ export class RequestURITooLongError extends ClientError {
             code: options.code ?? RequestURITooLongErrorOptions.code,
             status: options.status ?? options.statusCode ?? RequestURITooLongErrorOptions.status,
         });
+        markInstanceof(this, REQUEST_URI_TOO_LONG_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/415-unsupported-media-type.ts
+++ b/packages/http/src/errors/client/415-unsupported-media-type.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const UNSUPPORTED_MEDIA_TYPE_ERROR_INSTANCE = Symbol.for('@ebec/http/UnsupportedMediaTypeError');
 
 export const UnsupportedMediaTypeErrorOptions = {
     code: 'UNSUPPORTED_MEDIA_TYPE',
@@ -14,5 +17,6 @@ export class UnsupportedMediaTypeError extends ClientError {
             code: options.code ?? UnsupportedMediaTypeErrorOptions.code,
             status: options.status ?? options.statusCode ?? UnsupportedMediaTypeErrorOptions.status,
         });
+        markInstanceof(this, UNSUPPORTED_MEDIA_TYPE_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/416-requested-range-not-satisfiable.ts
+++ b/packages/http/src/errors/client/416-requested-range-not-satisfiable.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const REQUESTED_RANGE_NOT_SATISFIABLE_ERROR_INSTANCE = Symbol.for('@ebec/http/RequestedRangeNotSatisfiableError');
 
 export const RequestedRangeNotSatisfiableErrorOptions = {
     code: 'REQUESTED_RANGE_NOT_SATISFIABLE',
@@ -14,5 +17,6 @@ export class RequestedRangeNotSatisfiableError extends ClientError {
             code: options.code ?? RequestedRangeNotSatisfiableErrorOptions.code,
             status: options.status ?? options.statusCode ?? RequestedRangeNotSatisfiableErrorOptions.status,
         });
+        markInstanceof(this, REQUESTED_RANGE_NOT_SATISFIABLE_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/417-expectation-failed.ts
+++ b/packages/http/src/errors/client/417-expectation-failed.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const EXPECTATION_FAILED_ERROR_INSTANCE = Symbol.for('@ebec/http/ExpectationFailedError');
 
 export const ExpectationFailedErrorOptions = {
     code: 'EXPECTATION_FAILED',
@@ -14,5 +17,6 @@ export class ExpectationFailedError extends ClientError {
             code: options.code ?? ExpectationFailedErrorOptions.code,
             status: options.status ?? options.statusCode ?? ExpectationFailedErrorOptions.status,
         });
+        markInstanceof(this, EXPECTATION_FAILED_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/418-im-a-teapot.ts
+++ b/packages/http/src/errors/client/418-im-a-teapot.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const IM_A_TEAPOT_ERROR_INSTANCE = Symbol.for('@ebec/http/ImATeapotError');
 
 export const ImATeapotErrorOptions = {
     code: 'IM_A_TEAPOT',
@@ -14,5 +17,6 @@ export class ImATeapotError extends ClientError {
             code: options.code ?? ImATeapotErrorOptions.code,
             status: options.status ?? options.statusCode ?? ImATeapotErrorOptions.status,
         });
+        markInstanceof(this, IM_A_TEAPOT_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/420-enhance-your-calm.ts
+++ b/packages/http/src/errors/client/420-enhance-your-calm.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const ENHANCE_YOUR_CALM_ERROR_INSTANCE = Symbol.for('@ebec/http/EnhanceYourCalmError');
 
 export const EnhanceYourCalmErrorOptions = {
     code: 'ENHANCE_YOUR_CALM',
@@ -14,5 +17,6 @@ export class EnhanceYourCalmError extends ClientError {
             code: options.code ?? EnhanceYourCalmErrorOptions.code,
             status: options.status ?? options.statusCode ?? EnhanceYourCalmErrorOptions.status,
         });
+        markInstanceof(this, ENHANCE_YOUR_CALM_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/422-unprocessable-entity.ts
+++ b/packages/http/src/errors/client/422-unprocessable-entity.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const UNPROCESSABLE_ENTITY_ERROR_INSTANCE = Symbol.for('@ebec/http/UnprocessableEntityError');
 
 export const UnprocessableEntityErrorOptions = {
     code: 'UNPROCESSABLE_ENTITY',
@@ -14,5 +17,6 @@ export class UnprocessableEntityError extends ClientError {
             code: options.code ?? UnprocessableEntityErrorOptions.code,
             status: options.status ?? options.statusCode ?? UnprocessableEntityErrorOptions.status,
         });
+        markInstanceof(this, UNPROCESSABLE_ENTITY_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/423-locked.ts
+++ b/packages/http/src/errors/client/423-locked.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const LOCKED_ERROR_INSTANCE = Symbol.for('@ebec/http/LockedError');
 
 export const LockedErrorOptions = {
     code: 'LOCKED',
@@ -14,5 +17,6 @@ export class LockedError extends ClientError {
             code: options.code ?? LockedErrorOptions.code,
             status: options.status ?? options.statusCode ?? LockedErrorOptions.status,
         });
+        markInstanceof(this, LOCKED_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/424-failed-dependency.ts
+++ b/packages/http/src/errors/client/424-failed-dependency.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const FAILED_DEPENDENCY_ERROR_INSTANCE = Symbol.for('@ebec/http/FailedDependencyError');
 
 export const FailedDependencyErrorOptions = {
     code: 'FAILED_DEPENDENCY',
@@ -14,5 +17,6 @@ export class FailedDependencyError extends ClientError {
             code: options.code ?? FailedDependencyErrorOptions.code,
             status: options.status ?? options.statusCode ?? FailedDependencyErrorOptions.status,
         });
+        markInstanceof(this, FAILED_DEPENDENCY_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/425-unordered-collection.ts
+++ b/packages/http/src/errors/client/425-unordered-collection.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const UNORDERED_COLLECTION_ERROR_INSTANCE = Symbol.for('@ebec/http/UnorderedCollectionError');
 
 export const UnorderedCollectionErrorOptions = {
     code: 'UNORDERED_COLLECTION',
@@ -14,5 +17,6 @@ export class UnorderedCollectionError extends ClientError {
             code: options.code ?? UnorderedCollectionErrorOptions.code,
             status: options.status ?? options.statusCode ?? UnorderedCollectionErrorOptions.status,
         });
+        markInstanceof(this, UNORDERED_COLLECTION_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/426-upgrade-required.ts
+++ b/packages/http/src/errors/client/426-upgrade-required.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const UPGRADE_REQUIRED_ERROR_INSTANCE = Symbol.for('@ebec/http/UpgradeRequiredError');
 
 export const UpgradeRequiredErrorOptions = {
     code: 'UPGRADE_REQUIRED',
@@ -14,5 +17,6 @@ export class UpgradeRequiredError extends ClientError {
             code: options.code ?? UpgradeRequiredErrorOptions.code,
             status: options.status ?? options.statusCode ?? UpgradeRequiredErrorOptions.status,
         });
+        markInstanceof(this, UPGRADE_REQUIRED_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/428-precondition-required.ts
+++ b/packages/http/src/errors/client/428-precondition-required.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const PRECONDITION_REQUIRED_ERROR_INSTANCE = Symbol.for('@ebec/http/PreconditionRequiredError');
 
 export const PreconditionRequiredErrorOptions = {
     code: 'PRECONDITION_REQUIRED',
@@ -14,5 +17,6 @@ export class PreconditionRequiredError extends ClientError {
             code: options.code ?? PreconditionRequiredErrorOptions.code,
             status: options.status ?? options.statusCode ?? PreconditionRequiredErrorOptions.status,
         });
+        markInstanceof(this, PRECONDITION_REQUIRED_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/429-too-many-requests.ts
+++ b/packages/http/src/errors/client/429-too-many-requests.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const TOO_MANY_REQUESTS_ERROR_INSTANCE = Symbol.for('@ebec/http/TooManyRequestsError');
 
 export const TooManyRequestsErrorOptions = {
     code: 'TOO_MANY_REQUESTS',
@@ -14,5 +17,6 @@ export class TooManyRequestsError extends ClientError {
             code: options.code ?? TooManyRequestsErrorOptions.code,
             status: options.status ?? options.statusCode ?? TooManyRequestsErrorOptions.status,
         });
+        markInstanceof(this, TOO_MANY_REQUESTS_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/431-request-header-fields-too-large.ts
+++ b/packages/http/src/errors/client/431-request-header-fields-too-large.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const REQUEST_HEADER_FIELDS_TOO_LARGE_ERROR_INSTANCE = Symbol.for('@ebec/http/RequestHeaderFieldsTooLargeError');
 
 export const RequestHeaderFieldsTooLargeErrorOptions = {
     code: 'REQUEST_HEADER_FIELDS_TOO_LARGE',
@@ -14,5 +17,6 @@ export class RequestHeaderFieldsTooLargeError extends ClientError {
             code: options.code ?? RequestHeaderFieldsTooLargeErrorOptions.code,
             status: options.status ?? options.statusCode ?? RequestHeaderFieldsTooLargeErrorOptions.status,
         });
+        markInstanceof(this, REQUEST_HEADER_FIELDS_TOO_LARGE_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/444-no-response.ts
+++ b/packages/http/src/errors/client/444-no-response.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const NO_RESPONSE_ERROR_INSTANCE = Symbol.for('@ebec/http/NoResponseError');
 
 export const NoResponseErrorOptions = {
     code: 'NO_RESPONSE',
@@ -14,5 +17,6 @@ export class NoResponseError extends ClientError {
             code: options.code ?? NoResponseErrorOptions.code,
             status: options.status ?? options.statusCode ?? NoResponseErrorOptions.status,
         });
+        markInstanceof(this, NO_RESPONSE_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/449-retry-with.ts
+++ b/packages/http/src/errors/client/449-retry-with.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const RETRY_WITH_ERROR_INSTANCE = Symbol.for('@ebec/http/RetryWithError');
 
 export const RetryWithErrorOptions = {
     code: 'RETRY_WITH',
@@ -14,5 +17,6 @@ export class RetryWithError extends ClientError {
             code: options.code ?? RetryWithErrorOptions.code,
             status: options.status ?? options.statusCode ?? RetryWithErrorOptions.status,
         });
+        markInstanceof(this, RETRY_WITH_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/450-blocked-by-windows-parental-controls.ts
+++ b/packages/http/src/errors/client/450-blocked-by-windows-parental-controls.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const BLOCKED_BY_WINDOWS_PARENTAL_CONTROLS_ERROR_INSTANCE = Symbol.for('@ebec/http/BlockedByWindowsParentalControlsError');
 
 export const BlockedByWindowsParentalControlsErrorOptions = {
     code: 'BLOCKED_BY_WINDOWS_PARENTAL_CONTROLS',
@@ -14,5 +17,6 @@ export class BlockedByWindowsParentalControlsError extends ClientError {
             code: options.code ?? BlockedByWindowsParentalControlsErrorOptions.code,
             status: options.status ?? options.statusCode ?? BlockedByWindowsParentalControlsErrorOptions.status,
         });
+        markInstanceof(this, BLOCKED_BY_WINDOWS_PARENTAL_CONTROLS_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/client/499-client-closed-request.ts
+++ b/packages/http/src/errors/client/499-client-closed-request.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ClientError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const CLIENT_CLOSED_REQUEST_ERROR_INSTANCE = Symbol.for('@ebec/http/ClientClosedRequestError');
 
 export const ClientClosedRequestErrorOptions = {
     code: 'CLIENT_CLOSED_REQUEST',
@@ -14,5 +17,6 @@ export class ClientClosedRequestError extends ClientError {
             code: options.code ?? ClientClosedRequestErrorOptions.code,
             status: options.status ?? options.statusCode ?? ClientClosedRequestErrorOptions.status,
         });
+        markInstanceof(this, CLIENT_CLOSED_REQUEST_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/server/500-internal-server-error.ts
+++ b/packages/http/src/errors/server/500-internal-server-error.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ServerError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const INTERNAL_SERVER_ERROR_INSTANCE = Symbol.for('@ebec/http/InternalServerError');
 
 export const InternalServerErrorOptions = {
     code: 'INTERNAL_SERVER_ERROR',
@@ -14,5 +17,6 @@ export class InternalServerError extends ServerError {
             code: options.code ?? InternalServerErrorOptions.code,
             status: options.status ?? options.statusCode ?? InternalServerErrorOptions.status,
         });
+        markInstanceof(this, INTERNAL_SERVER_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/server/501-not-implemented.ts
+++ b/packages/http/src/errors/server/501-not-implemented.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ServerError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const NOT_IMPLEMENTED_ERROR_INSTANCE = Symbol.for('@ebec/http/NotImplementedError');
 
 export const NotImplementedErrorOptions = {
     code: 'NOT_IMPLEMENTED',
@@ -14,5 +17,6 @@ export class NotImplementedError extends ServerError {
             code: options.code ?? NotImplementedErrorOptions.code,
             status: options.status ?? options.statusCode ?? NotImplementedErrorOptions.status,
         });
+        markInstanceof(this, NOT_IMPLEMENTED_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/server/502-bad-gateway.ts
+++ b/packages/http/src/errors/server/502-bad-gateway.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ServerError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const BAD_GATEWAY_ERROR_INSTANCE = Symbol.for('@ebec/http/BadGatewayError');
 
 export const BadGatewayErrorOptions = {
     code: 'BAD_GATEWAY',
@@ -14,5 +17,6 @@ export class BadGatewayError extends ServerError {
             code: options.code ?? BadGatewayErrorOptions.code,
             status: options.status ?? options.statusCode ?? BadGatewayErrorOptions.status,
         });
+        markInstanceof(this, BAD_GATEWAY_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/server/503-service-unavailable.ts
+++ b/packages/http/src/errors/server/503-service-unavailable.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ServerError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const SERVICE_UNAVAILABLE_ERROR_INSTANCE = Symbol.for('@ebec/http/ServiceUnavailableError');
 
 export const ServiceUnavailableErrorOptions = {
     code: 'SERVICE_UNAVAILABLE',
@@ -14,5 +17,6 @@ export class ServiceUnavailableError extends ServerError {
             code: options.code ?? ServiceUnavailableErrorOptions.code,
             status: options.status ?? options.statusCode ?? ServiceUnavailableErrorOptions.status,
         });
+        markInstanceof(this, SERVICE_UNAVAILABLE_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/server/504-gateway-timeout.ts
+++ b/packages/http/src/errors/server/504-gateway-timeout.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ServerError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const GATEWAY_TIMEOUT_ERROR_INSTANCE = Symbol.for('@ebec/http/GatewayTimeoutError');
 
 export const GatewayTimeoutErrorOptions = {
     code: 'GATEWAY_TIMEOUT',
@@ -14,5 +17,6 @@ export class GatewayTimeoutError extends ServerError {
             code: options.code ?? GatewayTimeoutErrorOptions.code,
             status: options.status ?? options.statusCode ?? GatewayTimeoutErrorOptions.status,
         });
+        markInstanceof(this, GATEWAY_TIMEOUT_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/server/505-http-version-not-supported.ts
+++ b/packages/http/src/errors/server/505-http-version-not-supported.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ServerError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const HTTP_VERSION_NOT_SUPPORTED_ERROR_INSTANCE = Symbol.for('@ebec/http/HTTPVersionNotSupportedError');
 
 export const HTTPVersionNotSupportedErrorOptions = {
     code: 'HTTP_VERSION_NOT_SUPPORTED',
@@ -14,5 +17,6 @@ export class HTTPVersionNotSupportedError extends ServerError {
             code: options.code ?? HTTPVersionNotSupportedErrorOptions.code,
             status: options.status ?? options.statusCode ?? HTTPVersionNotSupportedErrorOptions.status,
         });
+        markInstanceof(this, HTTP_VERSION_NOT_SUPPORTED_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/server/506-variant-also-negotiates.ts
+++ b/packages/http/src/errors/server/506-variant-also-negotiates.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ServerError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const VARIANT_ALSO_NEGOTIATES_ERROR_INSTANCE = Symbol.for('@ebec/http/VariantAlsoNegotiatesError');
 
 export const VariantAlsoNegotiatesErrorOptions = {
     code: 'VARIANT_ALSO_NEGOTIATES',
@@ -14,5 +17,6 @@ export class VariantAlsoNegotiatesError extends ServerError {
             code: options.code ?? VariantAlsoNegotiatesErrorOptions.code,
             status: options.status ?? options.statusCode ?? VariantAlsoNegotiatesErrorOptions.status,
         });
+        markInstanceof(this, VARIANT_ALSO_NEGOTIATES_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/server/507-insufficient-storage.ts
+++ b/packages/http/src/errors/server/507-insufficient-storage.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ServerError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const INSUFFICIENT_STORAGE_ERROR_INSTANCE = Symbol.for('@ebec/http/InsufficientStorageError');
 
 export const InsufficientStorageErrorOptions = {
     code: 'INSUFFICIENT_STORAGE',
@@ -14,5 +17,6 @@ export class InsufficientStorageError extends ServerError {
             code: options.code ?? InsufficientStorageErrorOptions.code,
             status: options.status ?? options.statusCode ?? InsufficientStorageErrorOptions.status,
         });
+        markInstanceof(this, INSUFFICIENT_STORAGE_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/server/508-loop-detected.ts
+++ b/packages/http/src/errors/server/508-loop-detected.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ServerError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const LOOP_DETECTED_ERROR_INSTANCE = Symbol.for('@ebec/http/LoopDetectedError');
 
 export const LoopDetectedErrorOptions = {
     code: 'LOOP_DETECTED',
@@ -14,5 +17,6 @@ export class LoopDetectedError extends ServerError {
             code: options.code ?? LoopDetectedErrorOptions.code,
             status: options.status ?? options.statusCode ?? LoopDetectedErrorOptions.status,
         });
+        markInstanceof(this, LOOP_DETECTED_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/server/509-bandwidth-limit-exceeded.ts
+++ b/packages/http/src/errors/server/509-bandwidth-limit-exceeded.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ServerError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const BANDWIDTH_LIMIT_EXCEEDED_ERROR_INSTANCE = Symbol.for('@ebec/http/BandwidthLimitExceededError');
 
 export const BandwidthLimitExceededErrorOptions = {
     code: 'BANDWIDTH_LIMIT_EXCEEDED',
@@ -14,5 +17,6 @@ export class BandwidthLimitExceededError extends ServerError {
             code: options.code ?? BandwidthLimitExceededErrorOptions.code,
             status: options.status ?? options.statusCode ?? BandwidthLimitExceededErrorOptions.status,
         });
+        markInstanceof(this, BANDWIDTH_LIMIT_EXCEEDED_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/server/510-not-extended.ts
+++ b/packages/http/src/errors/server/510-not-extended.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ServerError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const NOT_EXTENDED_ERROR_INSTANCE = Symbol.for('@ebec/http/NotExtendedError');
 
 export const NotExtendedErrorOptions = {
     code: 'NOT_EXTENDED',
@@ -14,5 +17,6 @@ export class NotExtendedError extends ServerError {
             code: options.code ?? NotExtendedErrorOptions.code,
             status: options.status ?? options.statusCode ?? NotExtendedErrorOptions.status,
         });
+        markInstanceof(this, NOT_EXTENDED_ERROR_INSTANCE);
     }
 }

--- a/packages/http/src/errors/server/511-network-authentication-required.ts
+++ b/packages/http/src/errors/server/511-network-authentication-required.ts
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { ServerError } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const NETWORK_AUTHENTICATION_REQUIRED_ERROR_INSTANCE = Symbol.for('@ebec/http/NetworkAuthenticationRequiredError');
 
 export const NetworkAuthenticationRequiredErrorOptions = {
     code: 'NETWORK_AUTHENTICATION_REQUIRED',
@@ -14,5 +17,6 @@ export class NetworkAuthenticationRequiredError extends ServerError {
             code: options.code ?? NetworkAuthenticationRequiredErrorOptions.code,
             status: options.status ?? options.statusCode ?? NetworkAuthenticationRequiredErrorOptions.status,
         });
+        markInstanceof(this, NETWORK_AUTHENTICATION_REQUIRED_ERROR_INSTANCE);
     }
 }

--- a/packages/http/template/error.tpl
+++ b/packages/http/template/error.tpl
@@ -1,5 +1,8 @@
+import { markInstanceof } from '@ebec/core';
 import { {{baseClass}} } from '../base';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
+
+export const {{instanceConstantName}} = Symbol.for('@ebec/http/{{{class}}}');
 
 export const {{{class}}}Options = {
     code: '{{code}}',
@@ -14,5 +17,6 @@ export class {{{class}}} extends {{baseClass}} {
             code: options.code ?? {{{class}}}Options.code,
             status: options.status ?? options.statusCode ?? {{{class}}}Options.status,
         });
+        markInstanceof(this, {{instanceConstantName}});
     }
 }

--- a/packages/http/test/unit/module.spec.ts
+++ b/packages/http/test/unit/module.spec.ts
@@ -1,9 +1,17 @@
+import { INSTANCEOF_PROPERTY, hasInstanceof } from '@ebec/core';
 import { describe, expect, it } from 'vitest';
 import {
+    BAD_REQUEST_ERROR_INSTANCE,
+    BadRequestError,
+    CLIENT_ERROR_INSTANCE,
     ClientError,
     HTTPError,
+    HTTP_ERROR_INSTANCE,
+    INTERNAL_SERVER_ERROR_INSTANCE,
     InternalServerError,
+    NOT_FOUND_ERROR_INSTANCE,
     NotFoundError,
+    SERVER_ERROR_INSTANCE,
     ServerError,
     isClientError,
     isHTTPError,
@@ -117,5 +125,64 @@ describe('src/module.ts', () => {
 
     it('should not recognize non-HTTPError as http error', () => {
         expect(isHTTPError(undefined)).toBeFalsy();
+    });
+
+    describe('instanceof markers', () => {
+        it('should attach a Symbol.for marker chain to every HTTPError instance', () => {
+            const error = new HTTPError({ status: 418 });
+
+            expect(hasInstanceof(error, HTTP_ERROR_INSTANCE)).toBe(true);
+            expect(hasInstanceof(error, CLIENT_ERROR_INSTANCE)).toBe(false);
+            expect(hasInstanceof(error, SERVER_ERROR_INSTANCE)).toBe(false);
+        });
+
+        it('should accumulate ancestor markers on ClientError subclasses', () => {
+            const error = new BadRequestError();
+
+            expect(hasInstanceof(error, HTTP_ERROR_INSTANCE)).toBe(true);
+            expect(hasInstanceof(error, CLIENT_ERROR_INSTANCE)).toBe(true);
+            expect(hasInstanceof(error, BAD_REQUEST_ERROR_INSTANCE)).toBe(true);
+            expect(hasInstanceof(error, NOT_FOUND_ERROR_INSTANCE)).toBe(false);
+            expect(hasInstanceof(error, SERVER_ERROR_INSTANCE)).toBe(false);
+        });
+
+        it('should accumulate ancestor markers on ServerError subclasses', () => {
+            const error = new InternalServerError();
+
+            expect(hasInstanceof(error, HTTP_ERROR_INSTANCE)).toBe(true);
+            expect(hasInstanceof(error, SERVER_ERROR_INSTANCE)).toBe(true);
+            expect(hasInstanceof(error, INTERNAL_SERVER_ERROR_INSTANCE)).toBe(true);
+            expect(hasInstanceof(error, CLIENT_ERROR_INSTANCE)).toBe(false);
+        });
+
+        it('should resolve markers across independent Symbol.for lookups (cross-realm)', () => {
+            const error = new NotFoundError();
+
+            // A fresh lookup with the same key resolves to the identical symbol —
+            // this is what makes the marker survive cross-bundle / cross-realm boundaries.
+            expect(hasInstanceof(error, Symbol.for('@ebec/http/HTTPError'))).toBe(true);
+            expect(hasInstanceof(error, Symbol.for('@ebec/http/ClientError'))).toBe(true);
+            expect(hasInstanceof(error, Symbol.for('@ebec/http/NotFoundError'))).toBe(true);
+        });
+
+        it('should let isHTTPError fast-path-match a marker-only object', () => {
+            // Simulate a foreign-realm instance: no prototype link, just the chain.
+            const foreign: Record<string, unknown> = {};
+            Object.defineProperty(foreign, INSTANCEOF_PROPERTY, {
+                value: [HTTP_ERROR_INSTANCE, CLIENT_ERROR_INSTANCE],
+                enumerable: false,
+            });
+
+            expect(isHTTPError(foreign)).toBe(true);
+            expect(isClientError(foreign)).toBe(true);
+            expect(isServerError(foreign)).toBe(false);
+        });
+
+        it('should keep the marker chain out of toJSON output', () => {
+            const error = new NotFoundError('User not found');
+            const json = error.toJSON();
+
+            expect((json as Record<string, unknown>)[INSTANCEOF_PROPERTY]).toBeUndefined();
+        });
     });
 });


### PR DESCRIPTION
closes #429 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error detection across different JavaScript execution contexts (cross-realm instances)
  * Enhanced error type identification with more reliable validation logic

* **New Features**
  * Symbol-based instance marking for all error types enabling consistent identification
  * Better error type guards for ClientError, ServerError, and HTTPError classes

* **Tests**
  * Comprehensive test coverage for symbol-based instance marking and cross-realm scenarios

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/ebec/pull/430)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->