### PR TITLE
feat: keep @instanceof marker chain across JSON serialization

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -29,7 +29,16 @@ class BaseError extends Error {
 
 ### Serialization
 
-`toJSON()` returns `{ name, message, code, cause? }`. If `cause` is a `BaseError`, it is serialized recursively via `toJSON()`. Otherwise, the raw cause value is included.
+`toJSON()` returns `{ name, message, code, cause?, '@instanceof' }`. If `cause` is a `BaseError`, it is serialized recursively via `toJSON()`. Otherwise, the raw cause value is included.
+
+The `@instanceof` key carries the class-marker chain (see below) as a string list — the markers' `Symbol.for(...)` registry keys — since symbols are dropped by `JSON.stringify`. `serializeInstanceofChain(input)` produces this form.
+
+## @instanceof Markers
+
+Every class in the hierarchy declares a `Symbol.for(...)` marker (e.g. `BASE_ERROR_INSTANCE`, `HTTP_ERROR_INSTANCE`) and appends it to the instance's non-enumerable `@instanceof` chain via `markInstanceof(this, MARKER)` in its constructor. Subclass instances accumulate markers from every ancestor, so a parent-class guard can fast-path-match a subclass instance across bundle/realm boundaries.
+
+- `hasInstanceof(input, marker)` — strict form, matches the marker symbol only
+- `matchesInstanceof(input, marker)` — matches the symbol **or** its description string; use this as the guard fast path so the inheritance match survives a JSON round-trip (`toJSON()` serializes the chain to strings)
 
 ## HTTPError Properties
 
@@ -92,3 +101,5 @@ Each level provides a type guard for duck-type checking:
 | `isHTTPError(x)` | @ebec/http | Is error with numeric status (or statusCode) 400-599 |
 | `isClientError(x)` | @ebec/http | isHTTPError + status 400-499 |
 | `isServerError(x)` | @ebec/http | isHTTPError + status 500-599 |
+
+Each guard checks `matchesInstanceof(x, MARKER)` as its fast path before falling back to the shape checks above. New guards must use `matchesInstanceof` (not `hasInstanceof`) so JSON-rehydrated errors keep the inheritance match.

--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -15,11 +15,14 @@ ebec/
 │   │   │   │   ├── module.ts  # isErrorOptions(), extractErrorOptions()
 │   │   │   │   └── types.ts   # ErrorOptions type
 │   │   │   └── helpers/
-│   │   │       ├── check.ts        # isBaseError()
+│   │   │       ├── check.ts        # isBaseError(), isBaseErrorGroup()
+│   │   │       ├── error.ts        # isError()
 │   │   │       ├── error-code.ts   # isErrorWithCode()
+│   │   │       ├── instanceof.ts   # markInstanceof(), hasInstanceof(), matchesInstanceof(), serializeInstanceofChain()
 │   │   │       ├── interpolate.ts  # Message template interpolation
 │   │   │       ├── object.ts       # isObject() helper
-│   │   │       └── sanitize-code.ts # sanitizeErrorCode()
+│   │   │       ├── sanitize-code.ts # sanitizeErrorCode()
+│   │   │       └── serialize.ts    # toSerializable()
 │   │   ├── test/unit/
 │   │   ├── tsdown.config.ts
 │   │   └── package.json

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -127,9 +127,21 @@ console.log(JSON.stringify(error, null, 2));
 //   "cause": {
 //     "name": "BaseError",
 //     "message": "inner",
-//     "code": "INNER"
-//   }
+//     "code": "INNER",
+//     "@instanceof": ["@ebec/core/BaseError"]
+//   },
+//   "@instanceof": ["@ebec/core/BaseError"]
 // }
+```
+
+The `@instanceof` key carries the class-marker chain — one `Symbol.for(...)` registry key per class in the inheritance path — as a string list, since symbols don't survive `JSON.stringify`. Use `matchesInstanceof` to match a marker against both the in-process symbol chain and the rehydrated string chain:
+
+```typescript
+import { BASE_ERROR_INSTANCE, matchesInstanceof } from '@ebec/core';
+
+const rehydrated = JSON.parse(JSON.stringify(new BaseError('boom')));
+
+matchesInstanceof(rehydrated, BASE_ERROR_INSTANCE); // true
 ```
 
 ## Type Guards
@@ -251,7 +263,7 @@ class BaseError extends Error {
     cause?: unknown;
 
     constructor(input?: string | ErrorOptions);
-    toJSON(): { name: string; message: string; code: string; cause?: unknown; errors?: unknown[] };
+    toJSON(): { name: string; message: string; code: string; cause?: unknown; errors?: unknown[]; '@instanceof': string[] };
 }
 ```
 
@@ -284,6 +296,10 @@ class BaseError extends Error {
 | `extractErrorOptions(input)` | Normalizes `string \| ErrorOptions` to `ErrorOptions` |
 | `defineErrorCatalog(definitions)` | Creates typed error factory functions |
 | `toSerializable(input)` | Converts to JSON-safe form via `toJSON()` or `{ message }` fallback |
+| `markInstanceof(target, marker)` | Appends a `Symbol.for(...)` class marker to the target's `@instanceof` chain |
+| `hasInstanceof(input, marker)` | Checks the chain for the marker symbol (strict, in-process form only) |
+| `matchesInstanceof(input, marker)` | Checks the chain for the marker symbol **or** its description string (JSON-rehydrated form) |
+| `serializeInstanceofChain(input)` | Serializes the chain to its string form, as emitted by `toJSON()` |
 
 ## License
 

--- a/packages/core/src/helpers/check.ts
+++ b/packages/core/src/helpers/check.ts
@@ -7,7 +7,7 @@
 import type { IBaseError, IBaseErrorGroup } from '../types';
 import { isErrorOptions } from '../options';
 import { isError } from './error';
-import { hasInstanceof } from './instanceof';
+import { matchesInstanceof } from './instanceof';
 import { isObject } from './object';
 
 // Resolved via the global Symbol.for registry — same identity as
@@ -18,7 +18,7 @@ const BASE_ERROR_INSTANCE = Symbol.for('@ebec/core/BaseError');
 export function isBaseError(
     input: unknown,
 ): input is IBaseError {
-    if (hasInstanceof(input, BASE_ERROR_INSTANCE)) {
+    if (matchesInstanceof(input, BASE_ERROR_INSTANCE)) {
         return true;
     }
 

--- a/packages/core/src/helpers/instanceof.ts
+++ b/packages/core/src/helpers/instanceof.ts
@@ -12,7 +12,10 @@ import { isObject } from './object';
  *
  * The chain is a `symbol[]` of `Symbol.for(...)` markers — one per class in the
  * inheritance path. Stored as a non-enumerable, non-writable, non-configurable
- * property so it stays out of `Object.keys()` and `JSON.stringify()` output.
+ * property so it stays out of `Object.keys()` and plain `JSON.stringify()`
+ * output. `BaseError.toJSON()` re-emits it under the same key as a string
+ * list (see {@link serializeInstanceofChain}), so on objects rehydrated from
+ * that JSON the property holds a `string[]` instead.
  */
 export const INSTANCEOF_PROPERTY = '@instanceof' as const;
 
@@ -56,4 +59,65 @@ export function hasInstanceof(input: unknown, marker: symbol): boolean {
 
     const chain = input[INSTANCEOF_PROPERTY];
     return Array.isArray(chain) && chain.includes(marker);
+}
+
+/**
+ * Serialize the input's `@instanceof` class-marker chain to its string form.
+ *
+ * Symbols are dropped by `JSON.stringify`, so `BaseError.toJSON()` emits the
+ * chain as the markers' description strings instead. For `Symbol.for(...)`
+ * markers the description *is* the registry key, so the string form carries
+ * the same identity information as the symbol form.
+ *
+ * String entries pass through unchanged (a rehydrated chain re-serializes
+ * losslessly); anything else is dropped.
+ */
+export function serializeInstanceofChain(input: unknown): string[] {
+    if (!isObject(input)) {
+        return [];
+    }
+
+    const chain = input[INSTANCEOF_PROPERTY];
+    if (!Array.isArray(chain)) {
+        return [];
+    }
+
+    const output: string[] = [];
+    for (const entry of chain) {
+        if (typeof entry === 'symbol') {
+            if (entry.description) {
+                output.push(entry.description);
+            }
+        } else if (typeof entry === 'string') {
+            output.push(entry);
+        }
+    }
+
+    return output;
+}
+
+/**
+ * Check whether the input's `@instanceof` chain carries `marker` — either as
+ * the native registry symbol (an in-process instance) or as the symbol's
+ * description string (an error rehydrated from the JSON emitted by
+ * `BaseError.toJSON()`).
+ *
+ * Prefer this over {@link hasInstanceof} as the fast path of duck-type
+ * guards: `hasInstanceof` only matches the symbol form, so a guard using it
+ * loses the inheritance match for JSON-rehydrated subclass errors and falls
+ * through to its slow path.
+ */
+export function matchesInstanceof(input: unknown, marker: symbol): boolean {
+    if (hasInstanceof(input, marker)) {
+        return true;
+    }
+
+    if (!isObject(input)) {
+        return false;
+    }
+
+    const chain = input[INSTANCEOF_PROPERTY];
+    return Array.isArray(chain) &&
+        typeof marker.description === 'string' &&
+        chain.includes(marker.description);
 }

--- a/packages/core/src/helpers/instanceof.ts
+++ b/packages/core/src/helpers/instanceof.ts
@@ -70,7 +70,9 @@ export function hasInstanceof(input: unknown, marker: symbol): boolean {
  * the same identity information as the symbol form.
  *
  * String entries pass through unchanged (a rehydrated chain re-serializes
- * losslessly); anything else is dropped.
+ * losslessly); anything else is dropped. Each value is emitted once — a
+ * re-marked rehydrated chain can hold the same marker in both its string
+ * and symbol form.
  */
 export function serializeInstanceofChain(input: unknown): string[] {
     if (!isObject(input)) {
@@ -84,12 +86,17 @@ export function serializeInstanceofChain(input: unknown): string[] {
 
     const output: string[] = [];
     for (const entry of chain) {
+        let value: string | undefined;
         if (typeof entry === 'symbol') {
             if (entry.description) {
-                output.push(entry.description);
+                value = entry.description;
             }
         } else if (typeof entry === 'string') {
-            output.push(entry);
+            value = entry;
+        }
+
+        if (typeof value === 'string' && !output.includes(value)) {
+            output.push(value);
         }
     }
 

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -7,9 +7,11 @@
 
 import type { ErrorInput, IBaseError } from './types';
 import {
+    INSTANCEOF_PROPERTY,
     interpolate,
     markInstanceof,
     sanitizeErrorCode,
+    serializeInstanceofChain,
     toSerializable,
 } from './helpers';
 import { extractErrorOptions } from './options';
@@ -75,12 +77,19 @@ export class BaseError extends Error implements IBaseError {
         markInstanceof(this, BASE_ERROR_INSTANCE);
     }
 
+    /**
+     * The class-marker chain rides along as a string list so the ancestor
+     * information survives a JSON round-trip (symbols don't serialize) —
+     * duck-type guards match rehydrated subclass errors through it via
+     * `matchesInstanceof`.
+     */
     toJSON(): {
         name: string;
         message: string;
         code: string;
         cause?: unknown;
         errors?: unknown[];
+        [INSTANCEOF_PROPERTY]: string[];
     } {
         return {
             name: this.name,
@@ -88,6 +97,7 @@ export class BaseError extends Error implements IBaseError {
             code: this.code,
             ...(this.cause !== undefined && { cause: toSerializable(this.cause) }),
             ...(this.errors !== undefined && { errors: this.errors.map((e) => toSerializable(e)) }),
+            [INSTANCEOF_PROPERTY]: serializeInstanceofChain(this),
         };
     }
 }

--- a/packages/core/test/unit/group.spec.ts
+++ b/packages/core/test/unit/group.spec.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { BaseError, isBaseErrorGroup } from '../../src';
+import { BaseError, INSTANCEOF_PROPERTY, isBaseErrorGroup } from '../../src';
+
+const BASE_ERROR_CHAIN = ['@ebec/core/BaseError'];
 
 describe('errors grouping', () => {
     it('should create instance with errors option', () => {
@@ -51,7 +53,9 @@ describe('errors grouping', () => {
                 name: 'BaseError',
                 message: 'child',
                 code: 'CHILD',
+                [INSTANCEOF_PROPERTY]: BASE_ERROR_CHAIN,
             }],
+            [INSTANCEOF_PROPERTY]: BASE_ERROR_CHAIN,
         });
     });
 
@@ -77,9 +81,10 @@ describe('errors grouping', () => {
 
         expect(json.errors).toEqual([
             {
-                name: 'BaseError', 
-                message: 'structured', 
-                code: 'STRUCT', 
+                name: 'BaseError',
+                message: 'structured',
+                code: 'STRUCT',
+                [INSTANCEOF_PROPERTY]: BASE_ERROR_CHAIN,
             },
             { message: 'plain' },
         ]);

--- a/packages/core/test/unit/instanceof.spec.ts
+++ b/packages/core/test/unit/instanceof.spec.ts
@@ -151,6 +151,16 @@ describe('src/helpers/instanceof.ts', () => {
             expect(serializeInstanceofChain({})).toEqual([]);
             expect(serializeInstanceofChain({ [INSTANCEOF_PROPERTY]: 'not-an-array' })).toEqual([]);
         });
+
+        it('should emit each marker once when a re-marked rehydrated chain holds both forms', () => {
+            const rehydrated = JSON.parse(JSON.stringify(new BaseError('boom')));
+            // markInstanceof dedupes by symbol identity, so re-marking a
+            // rehydrated chain appends the symbol next to its string form.
+            markInstanceof(rehydrated, BASE_ERROR_INSTANCE);
+
+            expect(rehydrated[INSTANCEOF_PROPERTY]).toEqual(['@ebec/core/BaseError', BASE_ERROR_INSTANCE]);
+            expect(serializeInstanceofChain(rehydrated)).toEqual(['@ebec/core/BaseError']);
+        });
     });
 
     describe('matchesInstanceof', () => {
@@ -180,6 +190,16 @@ describe('src/helpers/instanceof.ts', () => {
 
             // eslint-disable-next-line symbol-description
             expect(matchesInstanceof(target, Symbol())).toBe(false);
+        });
+
+        it('should not match a local same-description symbol against a symbol chain', () => {
+            const target = {};
+
+            markInstanceof(target, Symbol.for('@ebec-test/MatchLocal'));
+
+            // Description matching applies to serialized string chains only —
+            // symbol entries still require registry identity.
+            expect(matchesInstanceof(target, Symbol('@ebec-test/MatchLocal'))).toBe(false);
         });
 
         it('should return false for non-object inputs and missing chains', () => {

--- a/packages/core/test/unit/instanceof.spec.ts
+++ b/packages/core/test/unit/instanceof.spec.ts
@@ -7,6 +7,8 @@ import {
     hasInstanceof,
     isBaseError,
     markInstanceof,
+    matchesInstanceof,
+    serializeInstanceofChain,
 } from '../../src';
 
 describe('src/helpers/instanceof.ts', () => {
@@ -112,6 +114,123 @@ describe('src/helpers/instanceof.ts', () => {
         });
     });
 
+    describe('serializeInstanceofChain', () => {
+        it('should serialize symbol markers to their description strings', () => {
+            const target = {};
+
+            markInstanceof(target, Symbol.for('@ebec-test/SerializeFoo'));
+            markInstanceof(target, Symbol.for('@ebec-test/SerializeBar'));
+
+            expect(serializeInstanceofChain(target)).toEqual([
+                '@ebec-test/SerializeFoo',
+                '@ebec-test/SerializeBar',
+            ]);
+        });
+
+        it('should pass string entries through unchanged', () => {
+            const target = { [INSTANCEOF_PROPERTY]: ['@ebec-test/Rehydrated', Symbol.for('@ebec-test/Native')] };
+
+            expect(serializeInstanceofChain(target)).toEqual([
+                '@ebec-test/Rehydrated',
+                '@ebec-test/Native',
+            ]);
+        });
+
+        it('should drop description-less symbols and non-string entries', () => {
+            const target = {
+                // eslint-disable-next-line symbol-description
+                [INSTANCEOF_PROPERTY]: [Symbol(), 42, null, Symbol.for('@ebec-test/Kept')],
+            };
+
+            expect(serializeInstanceofChain(target)).toEqual(['@ebec-test/Kept']);
+        });
+
+        it('should return an empty list for non-objects and missing or malformed chains', () => {
+            expect(serializeInstanceofChain(undefined)).toEqual([]);
+            expect(serializeInstanceofChain('string')).toEqual([]);
+            expect(serializeInstanceofChain({})).toEqual([]);
+            expect(serializeInstanceofChain({ [INSTANCEOF_PROPERTY]: 'not-an-array' })).toEqual([]);
+        });
+    });
+
+    describe('matchesInstanceof', () => {
+        it('should match the native symbol form', () => {
+            const target = {};
+            const marker = Symbol.for('@ebec-test/MatchSymbol');
+
+            markInstanceof(target, marker);
+
+            expect(matchesInstanceof(target, marker)).toBe(true);
+        });
+
+        it('should match the serialized string form', () => {
+            const target = { [INSTANCEOF_PROPERTY]: ['@ebec-test/MatchString'] };
+
+            expect(matchesInstanceof(target, Symbol.for('@ebec-test/MatchString'))).toBe(true);
+        });
+
+        it('should not match a marker absent from either form', () => {
+            const target = { [INSTANCEOF_PROPERTY]: ['@ebec-test/MatchPresent', Symbol.for('@ebec-test/MatchPresent')] };
+
+            expect(matchesInstanceof(target, Symbol.for('@ebec-test/MatchAbsent'))).toBe(false);
+        });
+
+        it('should not string-match a description-less marker', () => {
+            const target = { [INSTANCEOF_PROPERTY]: ['undefined'] };
+
+            // eslint-disable-next-line symbol-description
+            expect(matchesInstanceof(target, Symbol())).toBe(false);
+        });
+
+        it('should return false for non-object inputs and missing chains', () => {
+            const marker = Symbol.for('@ebec-test/MatchNone');
+
+            expect(matchesInstanceof(undefined, marker)).toBe(false);
+            expect(matchesInstanceof(null, marker)).toBe(false);
+            expect(matchesInstanceof({}, marker)).toBe(false);
+        });
+    });
+
+    describe('JSON round-trip', () => {
+        it('should emit the serialized chain in BaseError.toJSON output', () => {
+            const error = new BaseError('boom');
+
+            expect(error.toJSON()[INSTANCEOF_PROPERTY]).toEqual(['@ebec/core/BaseError']);
+        });
+
+        it('should keep the chain match after a JSON round-trip', () => {
+            const error = new BaseError('boom');
+            const rehydrated = JSON.parse(JSON.stringify(error));
+
+            expect(hasInstanceof(rehydrated, BASE_ERROR_INSTANCE)).toBe(false);
+            expect(matchesInstanceof(rehydrated, BASE_ERROR_INSTANCE)).toBe(true);
+            expect(isBaseError(rehydrated)).toBe(true);
+        });
+
+        it('should survive a double round-trip losslessly', () => {
+            const error = new BaseError('boom');
+            const once = JSON.parse(JSON.stringify(error));
+            // The rehydrated chain is a plain enumerable string list, so a
+            // second stringify carries it along without a toJSON hook.
+            const twice = JSON.parse(JSON.stringify(once));
+
+            expect(twice[INSTANCEOF_PROPERTY]).toEqual(['@ebec/core/BaseError']);
+            expect(matchesInstanceof(twice, BASE_ERROR_INSTANCE)).toBe(true);
+        });
+
+        it('should fall back gracefully for chain-less legacy payloads', () => {
+            const legacy = {
+                name: 'BaseError', 
+                message: 'boom', 
+                code: 'BASE_ERROR', 
+            };
+
+            expect(matchesInstanceof(legacy, BASE_ERROR_INSTANCE)).toBe(false);
+            // The guard still matches through its slow path (shape check).
+            expect(isBaseError(legacy)).toBe(true);
+        });
+    });
+
     describe('cross-realm identity via Symbol.for', () => {
         it('should match across independent Symbol.for lookups for the same key', () => {
             const target = {};
@@ -196,6 +315,14 @@ describe('src/helpers/instanceof.ts', () => {
 
             expect(hasInstanceof(foo, FOO_INSTANCE)).toBe(true);
             expect(hasInstanceof(foo, BAR_INSTANCE)).toBe(false);
+        });
+
+        it('should keep the ancestor match for a JSON-rehydrated subclass instance', () => {
+            const rehydrated = JSON.parse(JSON.stringify(new BarError('boom')));
+
+            expect(matchesInstanceof(rehydrated, BASE_ERROR_INSTANCE)).toBe(true);
+            expect(matchesInstanceof(rehydrated, FOO_INSTANCE)).toBe(true);
+            expect(matchesInstanceof(rehydrated, BAR_INSTANCE)).toBe(true);
         });
     });
 });

--- a/packages/core/test/unit/module.spec.ts
+++ b/packages/core/test/unit/module.spec.ts
@@ -1,6 +1,8 @@
 /* eslint-disable max-classes-per-file */
 import { describe, expect, it } from 'vitest';
-import { BaseError, isBaseError } from '../../src';
+import { BaseError, INSTANCEOF_PROPERTY, isBaseError } from '../../src';
+
+const BASE_ERROR_CHAIN = ['@ebec/core/BaseError'];
 
 describe('src/module.ts', () => {
     it('should create instance with message', () => {
@@ -48,6 +50,7 @@ describe('src/module.ts', () => {
             name: 'BaseError',
             message: 'test error',
             code: 'TEST',
+            [INSTANCEOF_PROPERTY]: BASE_ERROR_CHAIN,
         });
     });
 
@@ -68,7 +71,9 @@ describe('src/module.ts', () => {
                 name: 'BaseError',
                 message: 'inner',
                 code: 'INNER',
+                [INSTANCEOF_PROPERTY]: BASE_ERROR_CHAIN,
             },
+            [INSTANCEOF_PROPERTY]: BASE_ERROR_CHAIN,
         });
     });
 

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -82,6 +82,8 @@ throw new UserNotFoundError(42);
 
 All type guards use duck typing and return interface types (`IHTTPError`, `IClientError`, `IServerError`). They work with any object that has the right shape, not just `instanceof` checks.
 
+Each guard fast-path-matches the `@instanceof` class-marker chain via `matchesInstanceof` — as `Symbol.for(...)` markers on in-process instances, or as the string list that `toJSON()` emits under the `@instanceof` key. Guards therefore keep the full inheritance match (e.g. `isClientError` matching a `NotFoundError`) even for errors rehydrated from a JSON response body.
+
 ```typescript
 import {
     isHTTPError,

--- a/packages/http/src/errors/base/client.ts
+++ b/packages/http/src/errors/base/client.ts
@@ -1,4 +1,4 @@
-import { hasInstanceof, markInstanceof } from '@ebec/core';
+import { markInstanceof, matchesInstanceof } from '@ebec/core';
 import type { HTTPErrorInput } from '../../types';
 import { HTTPError, isHTTPError } from './http';
 import type { IClientError } from './types';
@@ -13,7 +13,7 @@ export class ClientError extends HTTPError implements IClientError {
 }
 
 export function isClientError(input: unknown): input is IClientError {
-    if (hasInstanceof(input, CLIENT_ERROR_INSTANCE)) {
+    if (matchesInstanceof(input, CLIENT_ERROR_INSTANCE)) {
         return true;
     }
 

--- a/packages/http/src/errors/base/http.ts
+++ b/packages/http/src/errors/base/http.ts
@@ -1,8 +1,8 @@
 import {
     BaseError,
-    hasInstanceof,
     isBaseError,
     markInstanceof,
+    matchesInstanceof,
 } from '@ebec/core';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 import {
@@ -57,7 +57,7 @@ export class HTTPError extends BaseError implements IHTTPError {
 }
 
 export function isHTTPError(input: unknown): input is IHTTPError {
-    if (hasInstanceof(input, HTTP_ERROR_INSTANCE)) {
+    if (matchesInstanceof(input, HTTP_ERROR_INSTANCE)) {
         return true;
     }
 

--- a/packages/http/src/errors/base/server.ts
+++ b/packages/http/src/errors/base/server.ts
@@ -1,4 +1,4 @@
-import { hasInstanceof, markInstanceof } from '@ebec/core';
+import { markInstanceof, matchesInstanceof } from '@ebec/core';
 import type { HTTPErrorInput } from '../../types';
 import { HTTPError, isHTTPError } from './http';
 import type { IServerError } from './types';
@@ -13,7 +13,7 @@ export class ServerError extends HTTPError implements IServerError {
 }
 
 export function isServerError(input: unknown): input is IServerError {
-    if (hasInstanceof(input, SERVER_ERROR_INSTANCE)) {
+    if (matchesInstanceof(input, SERVER_ERROR_INSTANCE)) {
         return true;
     }
 

--- a/packages/http/test/unit/module.spec.ts
+++ b/packages/http/test/unit/module.spec.ts
@@ -1,4 +1,4 @@
-import { INSTANCEOF_PROPERTY, hasInstanceof } from '@ebec/core';
+import { INSTANCEOF_PROPERTY, hasInstanceof, matchesInstanceof } from '@ebec/core';
 import { describe, expect, it } from 'vitest';
 import {
     BAD_REQUEST_ERROR_INSTANCE,
@@ -178,11 +178,41 @@ describe('src/module.ts', () => {
             expect(isServerError(foreign)).toBe(false);
         });
 
-        it('should keep the marker chain out of toJSON output', () => {
+        it('should emit the full marker chain in toJSON output', () => {
             const error = new NotFoundError('User not found');
             const json = error.toJSON();
 
-            expect((json as Record<string, unknown>)[INSTANCEOF_PROPERTY]).toBeUndefined();
+            expect((json as Record<string, unknown>)[INSTANCEOF_PROPERTY]).toEqual([
+                '@ebec/core/BaseError',
+                '@ebec/http/HTTPError',
+                '@ebec/http/ClientError',
+                '@ebec/http/NotFoundError',
+            ]);
+        });
+
+        it('should keep the ancestor match for a JSON-rehydrated subclass error', () => {
+            const rehydrated = JSON.parse(JSON.stringify(new NotFoundError()));
+
+            // Symbols are dropped by JSON.stringify — the strict form no
+            // longer matches, the serialized string form does.
+            expect(hasInstanceof(rehydrated, CLIENT_ERROR_INSTANCE)).toBe(false);
+            expect(matchesInstanceof(rehydrated, NOT_FOUND_ERROR_INSTANCE)).toBe(true);
+            expect(matchesInstanceof(rehydrated, CLIENT_ERROR_INSTANCE)).toBe(true);
+            expect(matchesInstanceof(rehydrated, HTTP_ERROR_INSTANCE)).toBe(true);
+
+            expect(isHTTPError(rehydrated)).toBe(true);
+            expect(isClientError(rehydrated)).toBe(true);
+            expect(isServerError(rehydrated)).toBe(false);
+        });
+
+        it('should keep guard matching for chain-less legacy payloads', () => {
+            const rehydrated = JSON.parse(JSON.stringify(new InternalServerError()));
+            delete rehydrated[INSTANCEOF_PROPERTY];
+
+            // Guards fall back to their status-based slow path.
+            expect(isHTTPError(rehydrated)).toBe(true);
+            expect(isServerError(rehydrated)).toBe(true);
+            expect(isClientError(rehydrated)).toBe(false);
         });
     });
 });


### PR DESCRIPTION
## Summary

Implements #448: the `Symbol.for`-keyed `@instanceof` class-marker chain now survives JSON serialization, so duck-type guards keep their inheritance-aware matching for errors rehydrated from a JSON body. This absorbs the package-side fallback authup shipped in authup/authup#3331 into ebec, where the mechanism lives.

- **`BaseError.toJSON()`** emits the chain as a string list (the markers' `symbol.description` values — for `Symbol.for` markers the description *is* the registry key) under the `@instanceof` key. All subclasses inherit this; `HTTPError.toJSON()` composes it automatically via `super.toJSON()`.
- **New `matchesInstanceof(input, marker)`** helper in `@ebec/core`: matches the marker as the native registry symbol (in-process) **or** as its description string (rehydrated). `hasInstanceof` stays strict (symbol-only).
- **New `serializeInstanceofChain(input)`** helper: produces the string form; string entries pass through unchanged, so a rehydrated chain re-serializes losslessly.
- **Guard fast paths swept onto the helper**: `isBaseError` (core), `isHTTPError` / `isClientError` / `isServerError` (http).

```ts
const rehydrated = JSON.parse(JSON.stringify(new NotFoundError()));
isClientError(rehydrated); // now true — previously false (fell through to status shape check)
matchesInstanceof(rehydrated, CLIENT_ERROR_INSTANCE); // true
```

## Behavior notes

- **Wire format**: `toJSON()` payloads now carry an `@instanceof` string list (a few short strings per error). Old consumers ignore the extra key; chain-less legacy payloads still match through the guards' shape-check slow path (pinned by tests).
- **Trust**: a consumer rehydrating untrusted JSON can forge a chain, but that is the same trust class as forging `code` — duck guards are shape checks, not authentication.
- **No subtractive changes**: the chain fast path only ever *adds* matches; `markInstanceof` still installs the runtime chain as non-enumerable, so plain objects marked with it keep it out of `JSON.stringify`.

Once released, authup can drop its local `instanceof.ts` and re-export these primitives (removal trigger noted in authup/authup#3331).

## Testing

- Core: new suites for `serializeInstanceofChain` (symbol → string, string passthrough, malformed chains) and `matchesInstanceof` (dual-form matching, description-less markers), plus round-trip tests: single/double round-trip, rehydrated subclass ancestor match, chain-less legacy fallback.
- HTTP: `toJSON` now pinned to emit the full ancestor chain; round-trip guard matrix (`isClientError` on rehydrated `NotFoundError`, legacy payload fallback).
- `npm run build`, `npm run lint`, `npm run test` all green (80 core + 31 http tests).

closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)