### PR TITLE
fix(core): widen issue/error array params and return types to readonly

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -259,7 +259,7 @@ The tree is stored as given. Group nodes keep their children rather than being f
 import { flattenIssueItems } from '@ebec/core';
 
 const byField = Object.fromEntries(
-    flattenIssueItems([...error.issues]).map((item) => [item.path.join('.'), item.message]),
+    flattenIssueItems(error.issues).map((item) => [item.path.join('.'), item.message]),
 );
 ```
 
@@ -313,7 +313,7 @@ class BaseError extends Error {
     cause?: unknown;
 
     constructor(input?: string | ErrorOptions);
-    toJSON(): { name: string; message: string; code: string; cause?: unknown; errors?: unknown[]; issues?: Issue[]; '@instanceof': string[] };
+    toJSON(): { name: string; message: string; code: string; cause?: unknown; errors?: unknown[]; issues?: readonly Issue[]; '@instanceof': string[] };
 }
 ```
 
@@ -325,8 +325,8 @@ class BaseError extends Error {
 | `code` | `string` | Error identifier. Derived from class name if not set. |
 | `messageData` | `Record<string, unknown>` | Data for `{placeholder}` interpolation. Not stored. |
 | `cause` | `unknown` | Underlying cause of the error. |
-| `errors` | `Error[]` | Collection of errors for batch/group scenarios. |
-| `issues` | `Issue[]` | Structured validation failures, as an issue tree. |
+| `errors` | `readonly Error[]` | Collection of errors for batch/group scenarios. |
+| `issues` | `readonly Issue[]` | Structured validation failures, as an issue tree. |
 | `stack` | `string` | Override the stack trace. |
 
 ### Type Guards

--- a/packages/core/src/issue/flatten.ts
+++ b/packages/core/src/issue/flatten.ts
@@ -19,7 +19,7 @@ import type { Issue, IssueGroup, IssueItem } from './types';
  * Returned items are the **same object references** held by the tree, not
  * copies — cheap to call, but do not mutate what you get back.
  */
-export function flattenIssueItems(issues: Issue[]): IssueItem[] {
+export function flattenIssueItems(issues: readonly Issue[]): IssueItem[] {
     const output: IssueItem[] = [];
     for (const issue of issues) {
         if (isIssueItem(issue)) {
@@ -38,7 +38,7 @@ export function flattenIssueItems(issues: Issue[]): IssueItem[] {
  * reads outermost-first. As with {@link flattenIssueItems}, entries are
  * live references into the tree.
  */
-export function flattenIssueGroups(issues: Issue[]): IssueGroup[] {
+export function flattenIssueGroups(issues: readonly Issue[]): IssueGroup[] {
     const output: IssueGroup[] = [];
     for (const issue of issues) {
         if (isIssueGroup(issue)) {

--- a/packages/core/src/issue/prefix.ts
+++ b/packages/core/src/issue/prefix.ts
@@ -34,7 +34,7 @@ import type { Issue } from './types';
  * result also mutates it on the original. Copying happens unconditionally,
  * including for an empty `prefix`.
  */
-export function prefixIssuePath(issue: Issue, prefix: PropertyKey[]): Issue {
+export function prefixIssuePath(issue: Issue, prefix: readonly PropertyKey[]): Issue {
     const prefixed: Issue = {
         ...issue,
         path: [...prefix, ...(issue.path || [])],

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -98,7 +98,7 @@ export class BaseError extends Error implements IBaseError {
         code: string;
         cause?: unknown;
         errors?: unknown[];
-        issues?: Issue[];
+        issues?: readonly Issue[];
         [INSTANCEOF_PROPERTY]: string[];
     } {
         return {

--- a/packages/core/src/options/types.ts
+++ b/packages/core/src/options/types.ts
@@ -36,7 +36,7 @@ export type ErrorOptions = {
     /**
      * A collection of errors for batch/group error scenarios.
      */
-    errors?: Error[],
+    errors?: readonly Error[],
 
     /**
      * Structured validation failures, as an issue tree.
@@ -44,5 +44,5 @@ export type ErrorOptions = {
      * Stored as given — group nodes keep their children, since flattening
      * is `flattenIssueItems`' job at the consumer.
      */
-    issues?: Issue[],
+    issues?: readonly Issue[],
 };


### PR DESCRIPTION
## Summary

`1.3.0` added `issues` to `BaseError`, but the related types disagreed about mutability — so `@ebec/core` is currently hostile to the subclassing pattern it exists for.

| Location | Was |
|---|---|
| `BaseError.issues` | `ReadonlyArray<Issue>` ✅ |
| `ErrorOptions.issues` | `Issue[]` — mutable |
| `toJSON()` return `issues` | `Issue[]` — mutable |
| `flattenIssueItems` / `flattenIssueGroups` params | `Issue[]` — mutable |

The class hands a subclass a `ReadonlyArray<Issue>` and then refuses to take it back. Found by migrating `rapiq`, whose `BaseError` declares `public readonly issues: readonly Issue[]` and hit three errors immediately:

- `TS2345` — can't pass its own `issues` into `super({ ...options })`
- `TS2416` — can't override `toJSON()` with a readonly issues type
- `TS4114` — needs `override` (rapiq's own fix, not this PR's)

It's also why `packages/core/README.md` had to teach `flattenIssueItems([...error.issues])` — a defensive copy that existed only to satisfy a needlessly narrow parameter.

## Changes

Six signatures widened to `readonly`. No function body changed — the constructor already copies its input with a spread, and `toJSON()` already returns a fresh array.

- `ErrorOptions.issues` → `readonly Issue[]`
- `ErrorOptions.errors` → `readonly Error[]` — the same latent defect one property over, caught in review before it could resurface as a second hotfix
- `toJSON()` return `issues` → `readonly Issue[]`
- `flattenIssueItems`, `flattenIssueGroups` params → `readonly Issue[]`
- `prefixIssuePath` `prefix` param → `readonly PropertyKey[]`

`BaseError.issues` itself is unchanged — it was already correct, and is what the others now agree with. `IssueBase.path` and `IssueGroup.issues` are left alone: they're data-model fields, not call-surface parameters.

README updated to drop the now-unnecessary spread and to match the API tables.

## One compile-time break, deliberately shipped as a patch

Widening a **parameter** is non-breaking — callers can pass strictly more. Widening `toJSON()`'s **return** is not: `err.toJSON().issues.push(...)` compiles against 1.3.0 and stops compiling after this.

Shipping as `fix:` anyway, because `readonly` erases at compile time so runtime is byte-identical, the returned array was always a fresh copy so mutating it never affected the error, and cutting a major for a same-day type correction is disproportionate. The commit body states the narrowing explicitly so it lands in the changelog rather than being discovered via a broken build.

## Verification

- [x] `npm run build`, `test` (215), `lint`, `typecheck` — all clean
- [x] `src/issue/**` coverage still 100%
- [x] Confirmed against the real consumer: built `dist` copied into rapiq's gitignored `node_modules`, typechecked, then the published 1.3.0 restored. `TS2345` and `TS2416` gone; only rapiq's own `TS4114` remains. rapiq's tracked state verified unchanged before and after.

## Why this blocks the migrations

rapiq, validup and authup all need `1.3.1` before they can move off `blemish`. Patching around this downstream would have baked the same workaround into three repos.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Public error-handling APIs now accept readonly error and issue collections.
  - Error serialization and issue-processing results are documented as readonly, improving type safety.
  - Existing issue flattening and path-prefixing behavior remains unchanged.
  - Updated examples demonstrate direct use of readonly issue collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->