### PR TITLE
feat!: make type-guard identity chain-only

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -102,14 +102,16 @@ To add a new HTTP error: add an entry to the appropriate JSON file and run `npm 
 
 ## Type Guards
 
-Each level provides a type guard for duck-type checking:
+Identity is chain-only. Each class-identity guard (`isBaseError`, `isHTTPError`) is a single check: `matchesInstanceof(x, MARKER)` against its own class marker. There is no shape/duck-typing fallback — an object that merely looks right (Error-shaped with a string `code`, or carrying a `status` field) but was never marked no longer matches. `matchesInstanceof` covers both the in-process symbol chain and the string chain that `toJSON()` emits, so the match survives a JSON round-trip; only errors actually produced by `@ebec/core`/`@ebec/http` (or explicitly marked via `markInstanceof`) carry that chain.
+
+`isClientError`/`isServerError` are not class-identity checks — they are status-range refinements of `isHTTPError`. Each first matches its own marker (`CLIENT_ERROR_INSTANCE`/`SERVER_ERROR_INSTANCE`) as a fast path, and otherwise delegates identity to `isHTTPError` (chain-only itself) and decides by `status` range from there. That's why a bare `new HTTPError({ status: 404 })` — which never marks itself as a `ClientError` — still matches `isClientError`: it's a confirmed `HTTPError` by chain, refined by status. Do not "fix" this by gating on the subclass marker alone.
 
 | Function | Package | Checks |
 |----------|---------|--------|
-| `isBaseError(x)` | @ebec/core | Is object with valid Options shape + string message |
+| `isBaseError(x)` | @ebec/core | `matchesInstanceof(x, BASE_ERROR_INSTANCE)` — chain-only |
 | `isErrorWithCode(x, code)` | @ebec/core | isBaseError + code matches (single or array) |
-| `isHTTPError(x)` | @ebec/http | Is error with numeric status (or statusCode) 400-599 |
-| `isClientError(x)` | @ebec/http | isHTTPError + status 400-499 |
-| `isServerError(x)` | @ebec/http | isHTTPError + status 500-599 |
+| `isHTTPError(x)` | @ebec/http | `matchesInstanceof(x, HTTP_ERROR_INSTANCE)` — chain-only |
+| `isClientError(x)` | @ebec/http | Own marker match, else `isHTTPError` (chain-confirmed) + status 400-499 |
+| `isServerError(x)` | @ebec/http | Own marker match, else `isHTTPError` (chain-confirmed) + status 500-599 |
 
-Each guard checks `matchesInstanceof(x, MARKER)` as its fast path before falling back to the shape checks above. New guards must use `matchesInstanceof` (not `hasInstanceof`) so JSON-rehydrated errors keep the inheritance match.
+New identity guards must use `matchesInstanceof` (not `hasInstanceof`), so JSON-rehydrated errors keep the inheritance match — `hasInstanceof` only matches the native symbol chain and misses the string chain a JSON round-trip produces. A guard that is a class-identity check reduces to that single `matchesInstanceof` call; a guard that is a status/shape refinement of another guard (like `isClientError`/`isServerError`) should delegate identity to that guard rather than duplicating a marker/chain check.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -147,10 +147,12 @@ matchesInstanceof(rehydrated, BASE_ERROR_INSTANCE); // true
 
 ## Type Guards
 
+Identity is chain-only: `isBaseError` (and every other type guard in this library) checks the `@instanceof` marker chain, not the input's shape. An object that merely *looks* like a `BaseError` — including an error from another library that happens to carry a `code` — does not match. Only errors produced by `@ebec/core` (or explicitly marked via `markInstanceof`) carry the chain, in-process and through `toJSON()`.
+
 ```typescript
 import { isBaseError, isErrorWithCode } from '@ebec/core';
 
-// Check if any value is a BaseError-shaped object
+// Check if any value is a BaseError, by its @instanceof chain
 if (isBaseError(error)) {
     console.log(error.code);
 }
@@ -195,7 +197,7 @@ if (failures.length > 0) {
 }
 ```
 
-Use `isBaseErrorGroup` to check if an error carries grouped errors:
+Use `isBaseErrorGroup` to check if an error carries grouped errors. A present but empty `errors: []` does not count as a group — the array must be non-empty:
 
 ```typescript
 import { isBaseErrorGroup } from '@ebec/core';
@@ -333,8 +335,8 @@ class BaseError extends Error {
 
 | Function | Returns | Description |
 |----------|---------|-------------|
-| `isBaseError(input)` | `input is IBaseError` | Checks for Error with string `code` |
-| `isBaseErrorGroup(input)` | `input is IBaseErrorGroup` | Checks for `isBaseError` + `errors` array |
+| `isBaseError(input)` | `input is IBaseError` | Chain-only: true iff the `@instanceof` chain carries the `BaseError` marker. No shape fallback — a merely Error-shaped object with a `code` no longer matches |
+| `isBaseErrorGroup(input)` | `input is IBaseErrorGroup` | `isBaseError` + non-empty `errors` array |
 | `isErrorWithCode(input, code)` | `input is IBaseError & { code: C }` | Narrows code to specific value(s) |
 | `isError(input)` | `input is Error` | Duck-type check for Error-shaped objects |
 | `isErrorOptions(input)` | `input is ErrorOptions` | Validates options shape |

--- a/packages/core/src/helpers/check.ts
+++ b/packages/core/src/helpers/check.ts
@@ -5,40 +5,23 @@
  *  view the LICENSE file that was distributed with this source code.
  */
 import type { IBaseError, IBaseErrorGroup } from '../types';
-import { isErrorOptions } from '../options';
 import { isError } from './error';
 import { matchesInstanceof } from './instanceof';
-import { isObject } from './object';
 
 // Resolved via the global Symbol.for registry — same identity as
 // `BASE_ERROR_INSTANCE` exported from `../module`. Looking it up here
 // avoids a circular import (module.ts → helpers → check.ts → module.ts).
 const BASE_ERROR_INSTANCE = Symbol.for('@ebec/core/BaseError');
 
+// Identity is chain-only: an input either carries the BaseError marker
+// (natively, or as the marker's description string after a JSON round-trip)
+// or it isn't a BaseError. There is no shape-based fallback — an object that
+// merely looks like one (a foreign library's error carrying a `code`, a
+// hand-built `{ message, code }`) no longer matches.
 export function isBaseError(
     input: unknown,
 ): input is IBaseError {
-    if (matchesInstanceof(input, BASE_ERROR_INSTANCE)) {
-        return true;
-    }
-
-    if (!isObject(input)) {
-        return false;
-    }
-
-    if (
-        isError(input) &&
-        isErrorOptions(input)
-    ) {
-        return typeof input.code === 'string';
-    }
-
-    if (!isErrorOptions(input)) {
-        return false;
-    }
-
-    return typeof input.message === 'string' &&
-        typeof input.code === 'string';
+    return matchesInstanceof(input, BASE_ERROR_INSTANCE);
 }
 
 export function isBaseErrorGroup(
@@ -49,5 +32,5 @@ export function isBaseErrorGroup(
     }
 
     const { errors } = input as unknown as Record<string, unknown>;
-    return Array.isArray(errors) && errors.every((e) => isError(e));
+    return Array.isArray(errors) && errors.length > 0 && errors.every((e) => isError(e));
 }

--- a/packages/core/src/helpers/instanceof.ts
+++ b/packages/core/src/helpers/instanceof.ts
@@ -16,6 +16,12 @@ import { isObject } from './object';
  * output. `BaseError.toJSON()` re-emits it under the same key as a string
  * list (see {@link serializeInstanceofChain}), so on objects rehydrated from
  * that JSON the property holds a `string[]` instead.
+ *
+ * A well-formed chain always begins with `BASE_ERROR_INSTANCE` — every real
+ * ebec error is a `BaseError` first, and subclass markers are appended on
+ * top of it. Hand-built cross-realm stand-ins that carry a subclass marker
+ * without it can invert that hierarchy (e.g. matching `@ebec/http`'s
+ * `isHTTPError` while failing `@ebec/core`'s `isBaseError`).
  */
 export const INSTANCEOF_PROPERTY = '@instanceof' as const;
 

--- a/packages/core/src/helpers/instanceof.ts
+++ b/packages/core/src/helpers/instanceof.ts
@@ -53,18 +53,38 @@ export function markInstanceof(target: object, marker: symbol): void {
 }
 
 /**
- * Check whether the input's `@instanceof` chain contains `marker`.
+ * Check whether the input's `@instanceof` chain carries `marker`.
  *
  * Returns `false` for non-objects, objects without the chain, or chains
  * stored as a non-array value (defensive).
+ *
+ * By default (`strict: true`) only the native `Symbol.for(...)` form
+ * matches. Pass `strict: false` to also match the marker's description
+ * string against a serialized (string) chain — the form a chain takes
+ * after a `JSON.stringify`/`JSON.parse` round-trip. {@link matchesInstanceof}
+ * is `hasInstanceof(input, marker, false)`.
  */
-export function hasInstanceof(input: unknown, marker: symbol): boolean {
+export function hasInstanceof(input: unknown, marker: symbol, strict: boolean = true): boolean {
     if (!isObject(input)) {
         return false;
     }
 
     const chain = input[INSTANCEOF_PROPERTY];
-    return Array.isArray(chain) && chain.includes(marker);
+
+    if (!Array.isArray(chain)) {
+        return false;
+    }
+
+    if (chain.includes(marker)) {
+        return true;
+    }
+
+    if (strict) {
+        return false;
+    }
+
+    return typeof marker.description === 'string' &&
+        chain.includes(marker.description);
 }
 
 /**
@@ -115,22 +135,12 @@ export function serializeInstanceofChain(input: unknown): string[] {
  * description string (an error rehydrated from the JSON emitted by
  * `BaseError.toJSON()`).
  *
- * Prefer this over {@link hasInstanceof} as the fast path of duck-type
- * guards: `hasInstanceof` only matches the symbol form, so a guard using it
- * loses the inheritance match for JSON-rehydrated subclass errors and falls
- * through to its slow path.
+ * Prefer this over the strict (default) form of {@link hasInstanceof} as the
+ * fast path of duck-type guards: the strict form only matches the symbol
+ * form, so a guard using it loses the inheritance match for JSON-rehydrated
+ * subclass errors and falls through to its slow path. Equivalent to
+ * `hasInstanceof(input, marker, false)`.
  */
 export function matchesInstanceof(input: unknown, marker: symbol): boolean {
-    if (hasInstanceof(input, marker)) {
-        return true;
-    }
-
-    if (!isObject(input)) {
-        return false;
-    }
-
-    const chain = input[INSTANCEOF_PROPERTY];
-    return Array.isArray(chain) &&
-        typeof marker.description === 'string' &&
-        chain.includes(marker.description);
+    return hasInstanceof(input, marker, false);
 }

--- a/packages/core/src/helpers/instanceof.ts
+++ b/packages/core/src/helpers/instanceof.ts
@@ -58,11 +58,14 @@ export function markInstanceof(target: object, marker: symbol): void {
  * Returns `false` for non-objects, objects without the chain, or chains
  * stored as a non-array value (defensive).
  *
- * By default (`strict: true`) only the native `Symbol.for(...)` form
- * matches. Pass `strict: false` to also match the marker's description
- * string against a serialized (string) chain — the form a chain takes
- * after a `JSON.stringify`/`JSON.parse` round-trip. {@link matchesInstanceof}
- * is `hasInstanceof(input, marker, false)`.
+ * `strict` controls which chain entries count as a match. By default
+ * (`strict: true`) only the native `Symbol.for(...)` form matches, which is
+ * what an in-process instance carries. Pass `strict: false` to also match
+ * the marker's `description` string: symbols are dropped by
+ * `JSON.stringify`, so an error rehydrated from the JSON emitted by
+ * `BaseError.toJSON()` carries the marker's description string in its chain
+ * instead of the symbol, and only the loose form still recognizes it.
+ * {@link matchesInstanceof} is `hasInstanceof(input, marker, false)`.
  */
 export function hasInstanceof(input: unknown, marker: symbol, strict: boolean = true): boolean {
     if (!isObject(input)) {
@@ -136,10 +139,11 @@ export function serializeInstanceofChain(input: unknown): string[] {
  * `BaseError.toJSON()`).
  *
  * Prefer this over the strict (default) form of {@link hasInstanceof} as the
- * fast path of duck-type guards: the strict form only matches the symbol
- * form, so a guard using it loses the inheritance match for JSON-rehydrated
- * subclass errors and falls through to its slow path. Equivalent to
- * `hasInstanceof(input, marker, false)`.
+ * fast path of duck-type guards. Guards have no shape-based fallback, so the
+ * strict form is the only check one performs: it matches only the symbol
+ * form, so a guard built on it returns `false` outright for a
+ * JSON-rehydrated subclass error — there is no slower path to fall back to.
+ * Equivalent to `hasInstanceof(input, marker, false)`.
  */
 export function matchesInstanceof(input: unknown, marker: symbol): boolean {
     return hasInstanceof(input, marker, false);

--- a/packages/core/test/unit/check.spec.ts
+++ b/packages/core/test/unit/check.spec.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { BaseError, isErrorWithCode } from '../../src';
+import {
+    BaseError,
+    INSTANCEOF_PROPERTY,
+    isBaseError,
+    isBaseErrorGroup,
+    isErrorWithCode,
+} from '../../src';
 
 describe('src/check.ts', () => {
     describe('isErrorWithCode', () => {
@@ -29,6 +35,41 @@ describe('src/check.ts', () => {
 
         it('should return false for plain Error', () => {
             expect(isErrorWithCode(new Error(), 'FOO')).toBe(false);
+        });
+    });
+
+    describe('isBaseError', () => {
+        it('should reject input whose instanceof chain lacks the marker', () => {
+            const announced = {
+                name: 'SomethingElse',
+                message: 'not a base error',
+                code: 'OTHER',
+                [INSTANCEOF_PROPERTY]: ['some/OtherClass'],
+            };
+
+            expect(isBaseError(announced)).toBeFalsy();
+        });
+
+        it('should reject chain-less input now that there is no shape fallback', () => {
+            expect(isBaseError({ message: 'x', code: 'y' })).toBeFalsy();
+        });
+
+        it('should reject a foreign error carrying a code', () => {
+            expect(isBaseError({
+                name: 'PrismaError', 
+                message: 'db', 
+                code: 'P2002', 
+            })).toBeFalsy();
+        });
+    });
+
+    describe('isBaseErrorGroup', () => {
+        it('should not treat an explicitly empty errors array as a group', () => {
+            expect(isBaseErrorGroup(new BaseError({ errors: [] }))).toBeFalsy();
+        });
+
+        it('should treat a non-empty errors array as a group', () => {
+            expect(isBaseErrorGroup(new BaseError({ errors: [new Error('a')] }))).toBeTruthy();
         });
     });
 });

--- a/packages/core/test/unit/instanceof.spec.ts
+++ b/packages/core/test/unit/instanceof.spec.ts
@@ -238,16 +238,16 @@ describe('src/helpers/instanceof.ts', () => {
             expect(matchesInstanceof(twice, BASE_ERROR_INSTANCE)).toBe(true);
         });
 
-        it('should fall back gracefully for chain-less legacy payloads', () => {
+        it('should reject chain-less legacy payloads now that identity is chain-only', () => {
             const legacy = {
-                name: 'BaseError', 
-                message: 'boom', 
-                code: 'BASE_ERROR', 
+                name: 'BaseError',
+                message: 'boom',
+                code: 'BASE_ERROR',
             };
 
             expect(matchesInstanceof(legacy, BASE_ERROR_INSTANCE)).toBe(false);
-            // The guard still matches through its slow path (shape check).
-            expect(isBaseError(legacy)).toBe(true);
+            // No shape fallback remains — a missing chain is a definitive no.
+            expect(isBaseError(legacy)).toBe(false);
         });
     });
 

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -4,7 +4,7 @@
 [![main](https://github.com/tada5hi/ebec/actions/workflows/main.yml/badge.svg)](https://github.com/tada5hi/ebec/actions/workflows/main.yml)
 [![codecov](https://codecov.io/gh/tada5hi/ebec/branch/master/graph/badge.svg?token=HLHCWI3VO1)](https://codecov.io/gh/tada5hi/ebec)
 
-HTTP error classes for TypeScript, extending [`@ebec/core`](../core). Provides 43 pre-built error classes for HTTP 4xx and 5xx status codes with duck-typed type guards.
+HTTP error classes for TypeScript, extending [`@ebec/core`](../core). Provides 43 pre-built error classes for HTTP 4xx and 5xx status codes with `@instanceof`-chain-based type guards.
 
 **Table of Contents**
 
@@ -80,9 +80,9 @@ throw new UserNotFoundError(42);
 
 ## Type Guards
 
-All type guards use duck typing and return interface types (`IHTTPError`, `IClientError`, `IServerError`). They work with any object that has the right shape, not just `instanceof` checks.
+Type guards check the `@instanceof` class-marker chain and return interface types (`IHTTPError`, `IClientError`, `IServerError`). Identity is chain-only — there is no duck-typing shape fallback. An object that merely has the right shape (a `status` field, a `code`, even one carried over from another HTTP error library) is not recognised; only errors that actually carry the `@ebec/http` marker chain are.
 
-Each guard fast-path-matches the `@instanceof` class-marker chain via `matchesInstanceof` — as `Symbol.for(...)` markers on in-process instances, or as the string list that `toJSON()` emits under the `@instanceof` key. Guards therefore keep the full inheritance match (e.g. `isClientError` matching a `NotFoundError`) even for errors rehydrated from a JSON response body.
+`isHTTPError` matches via `matchesInstanceof` — as a `Symbol.for(...)` marker on in-process instances, or as the string list that `toJSON()` emits under the `@instanceof` key — so the match survives a JSON round-trip. `isClientError` and `isServerError` are status-range refinements, not separate identity checks: each first matches its own chain marker (so a `NotFoundError` matches `isClientError` outright), and otherwise delegates identity to `isHTTPError` and decides by `status` range from there. That's why a bare `new HTTPError({ status: 404 })` — which never marks itself as a `ClientError` — still matches `isClientError`: it's a confirmed `HTTPError` by chain, refined by status.
 
 ```typescript
 import {
@@ -207,9 +207,9 @@ Plus all fields from [`@ebec/core` ErrorOptions](../core#erroroptions).
 
 | Function | Returns | Checks |
 |----------|---------|--------|
-| `isHTTPError(input)` | `input is IHTTPError` | status 400-599, passes `isBaseError` |
-| `isClientError(input)` | `input is IClientError` | `isHTTPError` + status 400-499 |
-| `isServerError(input)` | `input is IServerError` | `isHTTPError` + status 500-599 |
+| `isHTTPError(input)` | `input is IHTTPError` | Chain-only: true iff the `@instanceof` chain carries the `HTTPError` marker. No shape/status fallback |
+| `isClientError(input)` | `input is IClientError` | Own chain marker match; otherwise delegates identity to `isHTTPError` (chain-confirmed) + status 400-499 |
+| `isServerError(input)` | `input is IServerError` | Own chain marker match; otherwise delegates identity to `isHTTPError` (chain-confirmed) + status 500-599 |
 | `isErrorOptions(input)` | `input is ErrorOptions` | Validates HTTP options shape |
 
 ### Utilities

--- a/packages/http/src/errors/base/client.ts
+++ b/packages/http/src/errors/base/client.ts
@@ -17,6 +17,12 @@ export function isClientError(input: unknown): input is IClientError {
         return true;
     }
 
+    // Identity wins first (the marker match above): a ClientError instance
+    // matches regardless of status. Otherwise chain authority is delegated
+    // to isHTTPError — chain-only itself, so it rejects anything that isn't
+    // a confirmed HTTPError — and status range decides from there, so a bare
+    // `new HTTPError({ status: 404 })`, which never marks itself as a
+    // ClientError, still counts as a client error.
     if (!isHTTPError(input)) {
         return false;
     }

--- a/packages/http/src/errors/base/http.ts
+++ b/packages/http/src/errors/base/http.ts
@@ -1,13 +1,11 @@
 import {
     BaseError,
-    isBaseError,
     markInstanceof,
     matchesInstanceof,
 } from '@ebec/core';
 import type { HTTPErrorInput, HTTPErrorOptions } from '../../types';
 import {
     getStatusText,
-    isHTTPErrorOptions,
     sanitizeStatusCode,
 } from '../../utils';
 import type { IHTTPError } from './types';
@@ -56,23 +54,10 @@ export class HTTPError extends BaseError implements IHTTPError {
     }
 }
 
+// Identity is chain-only, same as isBaseError: an input either carries the
+// HTTPError marker or it doesn't. There is no shape/status fallback — an
+// upstream error that merely carries a `status` field is no longer mirrored
+// onto our own response as if it were an HTTPError.
 export function isHTTPError(input: unknown): input is IHTTPError {
-    if (matchesInstanceof(input, HTTP_ERROR_INSTANCE)) {
-        return true;
-    }
-
-    if (!isHTTPErrorOptions(input)) {
-        return false;
-    }
-
-    const status = (input as Record<string, unknown>).status ?? (input as Record<string, unknown>).statusCode;
-    if (
-        typeof status !== 'number' ||
-        status < 400 ||
-        status >= 600
-    ) {
-        return false;
-    }
-
-    return isBaseError(input);
+    return matchesInstanceof(input, HTTP_ERROR_INSTANCE);
 }

--- a/packages/http/src/errors/base/server.ts
+++ b/packages/http/src/errors/base/server.ts
@@ -17,6 +17,12 @@ export function isServerError(input: unknown): input is IServerError {
         return true;
     }
 
+    // Identity wins first (the marker match above): a ServerError instance
+    // matches regardless of status. Otherwise chain authority is delegated
+    // to isHTTPError — chain-only itself, so it rejects anything that isn't
+    // a confirmed HTTPError — and status range decides from there, so a bare
+    // `new HTTPError({ status: 500 })`, which never marks itself as a
+    // ServerError, still counts as a server error.
     if (!isHTTPError(input)) {
         return false;
     }

--- a/packages/http/test/unit/module.spec.ts
+++ b/packages/http/test/unit/module.spec.ts
@@ -1,4 +1,9 @@
-import { INSTANCEOF_PROPERTY, hasInstanceof, matchesInstanceof } from '@ebec/core';
+import {
+    BaseError,
+    INSTANCEOF_PROPERTY,
+    hasInstanceof,
+    matchesInstanceof,
+} from '@ebec/core';
 import { describe, expect, it } from 'vitest';
 import {
     BAD_REQUEST_ERROR_INSTANCE,
@@ -108,12 +113,14 @@ describe('src/module.ts', () => {
         expect(isServerError(t1)).toBeFalsy();
         expect(isHTTPError(t1)).toBeTruthy();
 
+        // A chain-less plain Error with a status bolted on no longer matches —
+        // identity is chain-only now, there is no shape/status fallback.
         const t2 = new Error();
         (t2 as Record<string, unknown>).statusCode = 500;
         (t2 as Record<string, unknown>).code = 'SERVER_ERROR';
         expect(isClientError(t2)).toBeFalsy();
-        expect(isServerError(t2)).toBeTruthy();
-        expect(isHTTPError(t2)).toBeTruthy();
+        expect(isServerError(t2)).toBeFalsy();
+        expect(isHTTPError(t2)).toBeFalsy();
     });
 
     it('should normalize non-error status to 500', () => {
@@ -205,14 +212,60 @@ describe('src/module.ts', () => {
             expect(isServerError(rehydrated)).toBe(false);
         });
 
-        it('should keep guard matching for chain-less legacy payloads', () => {
+        it('should reject chain-less legacy payloads now that there is no status-based fallback', () => {
             const rehydrated = JSON.parse(JSON.stringify(new InternalServerError()));
             delete rehydrated[INSTANCEOF_PROPERTY];
 
-            // Guards fall back to their status-based slow path.
-            expect(isHTTPError(rehydrated)).toBe(true);
-            expect(isServerError(rehydrated)).toBe(true);
+            // No chain, no identity — status alone no longer decides.
+            expect(isHTTPError(rehydrated)).toBe(false);
+            expect(isServerError(rehydrated)).toBe(false);
             expect(isClientError(rehydrated)).toBe(false);
+        });
+
+        it('should reject an error whose chain lacks the HTTP marker', () => {
+            // Shaped like hapic's HttpResponseError: extends BaseError, carries an
+            // upstream status, but never announces itself as an HTTPError.
+            const upstream = {
+                ...new BaseError({ message: 'upstream failed', code: 'UPSTREAM' }).toJSON(),
+                status: 503,
+            };
+
+            expect(isHTTPError(upstream)).toBeFalsy();
+            expect(isServerError(upstream)).toBeFalsy();
+        });
+
+        it('should reject a chain-less object now that there is no shape fallback', () => {
+            expect(isHTTPError({
+                message: 'x',
+                code: 'y',
+                status: 404,
+            })).toBeFalsy();
+        });
+
+        it('should still accept a JSON round-tripped HTTP error', () => {
+            const json = JSON.parse(JSON.stringify(new NotFoundError()));
+
+            expect(isHTTPError(json)).toBeTruthy();
+            expect(isClientError(json)).toBeTruthy();
+        });
+
+        it('should treat a bare HTTPError as a client error by status, not identity', () => {
+            // isClientError is a status-range refinement of isHTTPError, not a
+            // class-identity check: a plain HTTPError never marks itself with
+            // CLIENT_ERROR_INSTANCE, yet still counts as a client error here.
+            const bare = new HTTPError({ status: 404 });
+
+            expect(isClientError(bare)).toBeTruthy();
+            expect(bare.toJSON()[INSTANCEOF_PROPERTY]).not.toContain(CLIENT_ERROR_INSTANCE.description);
+        });
+
+        it('should reject a non-HTTP error even when its status is in range', () => {
+            const upstream = {
+                ...new BaseError({ message: 'upstream failed', code: 'UPSTREAM' }).toJSON(),
+                status: 404,
+            };
+
+            expect(isClientError(upstream)).toBeFalsy();
         });
     });
 });


### PR DESCRIPTION
## Summary

Identity for ebec's type guards becomes **chain-only**. `isBaseError` and `isHTTPError` now require the `@instanceof` marker chain; the duck-typing shape fallback is gone.

**Breaking: `@ebec/core@2.0.0`, `@ebec/http@5.0.0`.**

## What was wrong

`BaseError.toJSON()` serializes the marker chain, so class identity survives a JSON round trip. The guards read it in **one direction only** — for a *yes*, never for a *no* — then fell through to shape matching:

```
chain says: ["@ebec/core/BaseError"]     // no HTTP marker
+ status: 503

isHTTPError(it)   -> true    <- the chain said no
isServerError(it) -> true
```

That's the mechanism behind a hazard `@authup/server-core` documents: hapic's `HttpResponseError` extends `BaseError`, carries an upstream `status`, and could have that status mirrored onto authup's own response — an upstream 400 reading as *"your request was malformed"* when the caller's request was fine. authup defends by **branch ordering**, because the guard wouldn't.

The shape fallback was also promiscuous in its own right:

```js
isBaseError({ name: 'PrismaError', message: 'db', code: 'P2002' })  // -> true
```

A Prisma error is not an ebec `BaseError`.

## What changed

Both guards reduce to a marker check:

```ts
export function isBaseError(input: unknown): input is IBaseError {
    return matchesInstanceof(input, BASE_ERROR_INSTANCE);
}
```

`matchesInstanceof` matches the `Symbol.for(...)` marker on in-process instances **or** the string list `toJSON()` emits, so the match survives serialization. Errors from `@ebec/core` 1.2.0 or later carry the chain automatically, in-process and through JSON.

**`isClientError` / `isServerError` keep their structure**, deliberately. They are status-range refinements, not separate identity checks: own marker first, otherwise identity is delegated to `isHTTPError` and `status` decides. So a bare `new HTTPError({ status: 404 })` — which never marks itself a `ClientError` — is still a client error.

**`isBaseErrorGroup`** separately: it accepted an explicitly empty `errors` array, because `[].every()` is vacuously true — the same shape as the `isValidupError` bug fixed in validup 2.0.1. It now requires a non-empty array. Unlike validup's case there's no identity signal to preserve; "group" describes a *state*, not a class.

**`hasInstanceof` / `matchesInstanceof` consolidated.** The two had near-duplicate bodies walking the same chain. `hasInstanceof(input, marker, strict = true)` now carries both behaviours and `matchesInstanceof` is a one-line alias. The default stays `strict`, so every existing two-argument caller is unaffected.

## Migration

Anything relying on shape matching must now carry the chain:

```ts
// no longer recognised
isBaseError({ message: 'oops', code: 'E_OOPS' })

// use a real error — chain is applied automatically, and survives toJSON()
isBaseError(new BaseError({ message: 'oops', code: 'E_OOPS' }))
```

**One narrow case loses recognition:** `@ebec/http@4.0.x` (pre-#430) resolving a deduped `@ebec/core@1.3.x` produces errors carrying only the BaseError marker, so a genuine `NotFoundError` from that mix reads `false`. It needs a mixed-version graph to occur, and shipping as a major is what makes it a documented change rather than a silent one.

## Not applied to validup, deliberately

Chain authority is only safe once a marker has been in the wild long enough. `BASE_ERROR_INSTANCE` and `HTTP_ERROR_INSTANCE` date from #430/#449, so any serialized ebec error carrying a chain carries the right marker.

`VALIDUP_ERROR_INSTANCE` is a day old. A `ValidupError` from 2.0.0 serializes a chain with no validup marker, so the same rule there would undo the fallback added in 2.0.1 for exactly that population. Two rules coexist until that window closes.

## Downstream

Swept read-only across rapiq, validup and authup — **no break from the chain-authority change**. rapiq has its own marker-only `isBaseError` and never calls ebec's; validup has no call sites; authup's single use sits behind its own chain branch.

**One follow-up for authup**, out of scope here: `isAuthupError` ends `if (!isBaseError(input)) return false;`, reached only for chain-less input. With `isBaseError` chain-only that branch is now dead, so authup's documented slow path for "plain objects rehydrated from JSON emitted by older builds" stops working. authup is mid-migration and will pick this up there.

## Verified

- [x] 225 tests, build, lint, typecheck clean
- [x] Contract from the committed build: foreign error → false; `{message, code}` → false; real `BaseError` → true; JSON round-trip → true; bare `HTTPError({404})` → client error; `{503}` → server error; empty group → false
- [x] `hasInstanceof` strict/loose matrix: live symbol true/true, JSON false/true — the third proving `strict` still defaults to `true`

## Docs

All four surfaces describing the old duck-typing contract are updated — both package READMEs and `.agents/architecture.md` — stating that identity is chain-only and that the client/server guards refine by status over a chain-confirmed HTTP error, with the reasoning, so the delegation doesn't get "corrected" back.
